### PR TITLE
Adds functionality to respect text-align property

### DIFF
--- a/addon/components/truncate-multiline.js
+++ b/addon/components/truncate-multiline.js
@@ -89,6 +89,16 @@ export default Ember.Component.extend(ResizeHandlerMixin, {
    */
   _didTruncate: false,
 
+   /**
+   * Whether or not the text is meant to be centered.
+   * @type {Boolean}
+   * @private
+   */
+  _isCenterAligned: Ember.computed(function() {
+    let styles = window.getComputedStyle(this.element, null);
+    return styles.textAlign === 'center';
+  }),
+
   /**
    * Kicks off the truncation after render.
    * @return {Void}
@@ -115,6 +125,9 @@ export default Ember.Component.extend(ResizeHandlerMixin, {
         el.removeChild(ellipsizedSpan);
         let wrappingSpan = document.createElement('span');
         wrappingSpan.classList.add(`${cssNamespace}--last-line-wrapper`);
+        if (this.get('_isCenterAligned')) {
+          wrappingSpan.classList.add(`${cssNamespace}--center-align`);
+        }
         wrappingSpan.appendChild(ellipsizedSpan);
         wrappingSpan.appendChild(button);
         el.appendChild(wrappingSpan);

--- a/tests/integration/components/truncate-multiline-test.js
+++ b/tests/integration/components/truncate-multiline-test.js
@@ -210,3 +210,18 @@ moduleForComponent('truncate-multiline', 'Integration | Component | truncate-mul
   assert.equal(this.$('#truncate-multiline--test-container')[0].style.width, '540px', 'the container was resized');
   assert.equal(this.$('#truncate-multiline--test-container').html().replace(/\n|  +/g, ''), '<div class="ember-view"><div class="truncate-multiline--truncation-target"><span>supercalifragilisticexpialidocious supercalifragilisticexpialidocious </span><span class="truncate-multiline--last-line-wrapper"><span>supercalifragilisticexpialidocious supercalifragilisticexpialidocious</span><button class="truncate-multiline--button-hidden"></button></span></div></div>', 'truncation after resizing');
 });
+
+test('adds centering class if the text is meant to be centered', function(assert) {
+  // Template block usage:
+  this.render(hbs`
+    <div style="width: 362px; font: 16px sans-serif; text-align: center;">
+      {{truncate-multiline showButton=false text="supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious"}}
+    </div>
+  `);
+
+  // remove attributes we have no control over
+  this.$('[id^=ember]').removeAttr('id');
+  this.$('[data-ember-action]').removeAttr('data-ember-action');
+
+  assert.equal(this.$().html().replace(/\n|  +/g, ''), '<div style="width: 362px; font: 16px sans-serif; text-align: center;"><div class="ember-view"><div class="truncate-multiline--truncation-target"><span>supercalifragilisticexpialidocious </span><span>supercalifragilisticexpialidocious </span><span class="truncate-multiline--last-line-wrapper truncate-multiline--center-align"><span class="truncate-multiline--last-line">supercalifragilisticexpialidocious supercalifragilisticexpialidocious</span><button class="truncate-multiline--button-hidden"><!----></button></span></div></div></div>');
+});

--- a/vendor/styles/truncate-multiline.css
+++ b/vendor/styles/truncate-multiline.css
@@ -19,3 +19,7 @@
 .truncate-multiline--last-line-wrapper {
   display: flex !important;
 }
+
+.truncate-multiline--center-align {
+  justify-content: center;
+}


### PR DESCRIPTION
Currently, `multiline-truncate` doesn't work when it's parent has `text-align: center` because it uses display flex. This PR fixes that issue.
