### PR TITLE
Make this add-on Fastboot Safe

### DIFF
--- a/addon/components/truncate-multiline.js
+++ b/addon/components/truncate-multiline.js
@@ -142,18 +142,24 @@ export default Ember.Component.extend(ResizeHandlerMixin, {
         let el = this.element.querySelector(`.${cssNamespace}--truncation-target`);
         let button = this.element.querySelector(`[class^=${cssNamespace}--button]`);
         
-        if (el) {
-          button.parentNode.removeChild(button);
-          clamp(el, this.get('lines'), (didTruncate) => this.set('_isTruncated', didTruncate), `${cssNamespace}--last-line`, window, document);
-          let ellipsizedSpan = el.lastChild;
+        
+        button.parentNode.removeChild(button);
+        clamp(el, this.get('lines'), (didTruncate) => this.set('_isTruncated', didTruncate), `${cssNamespace}--last-line`, window, document);
+        let ellipsizedSpan = el.lastChild;
+        
+        if (ellipsizedSpan) {
           el.removeChild(ellipsizedSpan);
-          let wrappingSpan = document.createElement('span');
-          wrappingSpan.classList.add(`${cssNamespace}--last-line-wrapper`);
-          wrappingSpan.appendChild(ellipsizedSpan);
-          wrappingSpan.appendChild(button);
-          el.appendChild(wrappingSpan);
-          this.set('_didTruncate', true);
         }
+        
+        let wrappingSpan = document.createElement('span');
+        wrappingSpan.classList.add(`${cssNamespace}--last-line-wrapper`);
+        
+        if (ellipsizedSpan) {
+          wrappingSpan.appendChild(ellipsizedSpan);
+        }
+        wrappingSpan.appendChild(button);
+        el.appendChild(wrappingSpan);
+        this.set('_didTruncate', true);
       });
     }
   },
@@ -189,10 +195,10 @@ export default Ember.Component.extend(ResizeHandlerMixin, {
     toggleTruncate() {
       let wasTruncated = this.get('truncate');
       this.toggleProperty('truncate');
-
+      
       if (wasTruncated) {
         let onExpand = this.attrs.onExpand;
-
+        
         if (onExpand) {
           if (typeof onExpand === 'function') {
             onExpand();
@@ -203,7 +209,7 @@ export default Ember.Component.extend(ResizeHandlerMixin, {
       } else {
         this._doTruncation();
         let onCollapse = this.attrs.onCollapse;
-
+        
         if (onCollapse) {
           if (typeof onCollapse === 'function') {
             onCollapse();
@@ -212,9 +218,9 @@ export default Ember.Component.extend(ResizeHandlerMixin, {
           }
         }
       }
-
+      
       let onToggleTruncate = this.attrs.onToggleTruncate;
-
+      
       if (onToggleTruncate) {
         if (typeof onToggleTruncate === 'function') {
           onToggleTruncate(!wasTruncated);

--- a/addon/components/truncate-multiline.js
+++ b/addon/components/truncate-multiline.js
@@ -119,7 +119,7 @@ export default Ember.Component.extend(ResizeHandlerMixin, {
    * Kicks off the truncation after render.
    * @return {Void}
    */
-  didRender() {
+  didInsertElement() {
     if (!this.get('_didTruncate')) {
       this._doTruncation();
     }

--- a/addon/components/truncate-multiline.js
+++ b/addon/components/truncate-multiline.js
@@ -119,7 +119,13 @@ export default Ember.Component.extend(ResizeHandlerMixin, {
    * Kicks off the truncation after render.
    * @return {Void}
    */
-  didInsertElement() {
+  // didInsertElement() {
+  //   if (!this.get('_didTruncate')) {
+  //     this._doTruncation();
+  //   }
+  // },
+  
+  didRender() {
     if (!this.get('_didTruncate')) {
       this._doTruncation();
     }

--- a/addon/components/truncate-multiline.js
+++ b/addon/components/truncate-multiline.js
@@ -136,7 +136,7 @@ export default Ember.Component.extend(ResizeHandlerMixin, {
         let el = this.element.querySelector(`.${cssNamespace}--truncation-target`);
         let button = this.element.querySelector(`[class^=${cssNamespace}--button]`);
         button.parentNode.removeChild(button);
-        clamp(el, this.get('lines'), (didTruncate) => this.set('_isTruncated', didTruncate), `${cssNamespace}--last-line`);
+        clamp(el, this.get('lines'), (didTruncate) => this.set('_isTruncated', didTruncate), `${cssNamespace}--last-line`, window, document);
         let ellipsizedSpan = el.lastChild;
         el.removeChild(ellipsizedSpan);
         let wrappingSpan = document.createElement('span');

--- a/addon/components/truncate-multiline.js
+++ b/addon/components/truncate-multiline.js
@@ -146,15 +146,11 @@ export default Ember.Component.extend(ResizeHandlerMixin, {
         button.parentNode.removeChild(button);
         clamp(el, this.get('lines'), (didTruncate) => this.set('_isTruncated', didTruncate), `${cssNamespace}--last-line`, window, document);
         let ellipsizedSpan = el.lastChild;
-        
-        if (ellipsizedSpan) {
-          el.removeChild(ellipsizedSpan);
-        }
-        
         let wrappingSpan = document.createElement('span');
         wrappingSpan.classList.add(`${cssNamespace}--last-line-wrapper`);
         
         if (ellipsizedSpan) {
+          el.removeChild(ellipsizedSpan);
           wrappingSpan.appendChild(ellipsizedSpan);
         }
         wrappingSpan.appendChild(button);

--- a/addon/components/truncate-multiline.js
+++ b/addon/components/truncate-multiline.js
@@ -141,16 +141,19 @@ export default Ember.Component.extend(ResizeHandlerMixin, {
       Ember.run.scheduleOnce('afterRender', this, () => {
         let el = this.element.querySelector(`.${cssNamespace}--truncation-target`);
         let button = this.element.querySelector(`[class^=${cssNamespace}--button]`);
-        button.parentNode.removeChild(button);
-        clamp(el, this.get('lines'), (didTruncate) => this.set('_isTruncated', didTruncate), `${cssNamespace}--last-line`, window, document);
-        let ellipsizedSpan = el.lastChild;
-        el.removeChild(ellipsizedSpan);
-        let wrappingSpan = document.createElement('span');
-        wrappingSpan.classList.add(`${cssNamespace}--last-line-wrapper`);
-        wrappingSpan.appendChild(ellipsizedSpan);
-        wrappingSpan.appendChild(button);
-        el.appendChild(wrappingSpan);
-        this.set('_didTruncate', true);
+        
+        if (el) {
+          button.parentNode.removeChild(button);
+          clamp(el, this.get('lines'), (didTruncate) => this.set('_isTruncated', didTruncate), `${cssNamespace}--last-line`, window, document);
+          let ellipsizedSpan = el.lastChild;
+          el.removeChild(ellipsizedSpan);
+          let wrappingSpan = document.createElement('span');
+          wrappingSpan.classList.add(`${cssNamespace}--last-line-wrapper`);
+          wrappingSpan.appendChild(ellipsizedSpan);
+          wrappingSpan.appendChild(button);
+          el.appendChild(wrappingSpan);
+          this.set('_didTruncate', true);
+        }
       });
     }
   },

--- a/addon/utils/clamp.js
+++ b/addon/utils/clamp.js
@@ -10,51 +10,71 @@
  * @param {String} cssClass - A CSS class applied to the last line instead of inline CSS.
  */
 
-export default (function(win, doc) {
-  var measure, text, lineWidth, pos,
-    lineStart, lineCount, wordStart,
-    line, lineText, wasNewLine,
-    nodeStack, seedQueue, pendingQueue,
-    textNode, measureWidth, thisNode, nextQueue,
-    ce = doc.createElement.bind(doc),
-    ctn = doc.createTextNode.bind(doc);
-
-  // measurement element is made a child of the clamped element to get it's style
-  measure = ce('span');
-
-  (function(s) {
-    s.position = 'absolute'; // prevent page reflow
-    s.whiteSpace = 'pre'; // cross-browser width results
-    s.visibility = 'hidden'; // prevent drawing
-  }(measure.style));
-
-  function appendNodeAndQueueToElement(element, node, queue) {
-    var queueLength = queue && queue.length,
-        i, aNode, bNode;
-    // add nodes waiting to be finalized
-    for(i = 0; i < queueLength; ++i) {
-      element.appendChild(queue[i]);
+let measure,
+    text,
+    lineWidth,
+    pos,
+    lineStart,
+    lineCount,
+    wordStart,
+    line,
+    lineText,
+    wasNewLine,
+    nodeStack,
+    seedQueue,
+    pendingQueue,
+    textNode,
+    measureWidth,
+    thisNode,
+    nextQueue,
+    ce,
+    ctn;
+    
+    if (window, document) {
+      window = document;
+      window = document;
+      doc = document;
+      
+      ce = doc.createElement.bind(doc);
+      ctn = doc.createTextNode.bind(doc);
+      // measurement element is made a child of the clamped element to get it's style
+      measure = ce('span');
+      
+      measure.style.position = 'absolute';  // prevent page reflow
+      measure.whiteSpace = 'pre'; // cross-browser width results
+      measure.visibility = 'hidden'; // prevent drawing
     }
-    if (nodeStack.length) {
-      // add nodes from the stack
-      i = nodeStack.length - 1;
-      // add the text to the last node on the stack
-      nodeStack[i].appendChild(node);
-      // ensure nodes from the stack are appended to each other
-      for (; i > 0 && (aNode = nodeStack[i]).parentNode !== (bNode = nodeStack[i - 1]); --i) {
-        bNode.appendChild(aNode);
-      }
-      // ensure root node from stack is added to measurement node
-      if ((aNode = nodeStack[0]).parentNode !== element) {
-        element.appendChild(aNode);
-      }
-    } else {
-      // add the text directly to the measurement node
-      element.appendChild(node);
-    }
-  } // function appendNodeAndQueueToElement
 
-  return function clamp(el, lineClamp, cb, cssClass) {
+function appendNodeAndQueueToElement(element, node, queue) {
+  var queueLength = queue && queue.length,
+      i, aNode, bNode;
+      
+  // add nodes waiting to be finalized
+  for(i = 0; i < queueLength; ++i) {
+    element.appendChild(queue[i]);
+  }
+  
+  if (nodeStack.length) {
+    // add nodes from the stack
+    i = nodeStack.length - 1;
+    // add the text to the last node on the stack
+    nodeStack[i].appendChild(node);
+    // ensure nodes from the stack are appended to each other
+    for (; i > 0 && (aNode = nodeStack[i]).parentNode !== (bNode = nodeStack[i - 1]); --i) {
+      bNode.appendChild(aNode);
+    }
+    // ensure root node from stack is added to measurement node
+    if ((aNode = nodeStack[0]).parentNode !== element) {
+      element.appendChild(aNode);
+    }
+  } else {
+    // add the text directly to the measurement node
+    element.appendChild(node);
+  }
+} // function appendNodeAndQueueToElement
+
+
+export default function clamp(el, lineClamp, cb, cssClass) {
     // make sure the element belongs to the document
     if (!el.ownerDocument || el.ownerDocument !== doc) {
       return;
@@ -232,5 +252,4 @@ export default (function(win, doc) {
 
     // call the callback with whether or not the text was truncated
     cb(lineCount > lineClamp);
-  }; // function clamp
-}(window, document));
+}; // function clamp

--- a/addon/utils/clamp.js
+++ b/addon/utils/clamp.js
@@ -29,18 +29,17 @@ let measure,
     nextQueue,
     ce,
     ctn,
-    win,
-    doc;
+    _win,
+    _doc;
     
-function init(_win, _doc) {
-  console.log(typeof(_win), typeof(_doc));
+function init(win, doc) {
   
-  if (typeof(_win) && typeof(_doc)) {
-    win = _win;
-    doc = _doc
+  if (typeof(win) && typeof(doc)) {
+    _win = win;
+    _doc = doc
     
-    ce = doc.createElement.bind(doc);
-    ctn = doc.createTextNode.bind(doc);
+    ce = _doc.createElement.bind(_doc);
+    ctn = _doc.createTextNode.bind(_doc);
     // measurement element is made a child of the clamped element to get it's style
     measure = ce('span');
     


### PR DESCRIPTION
Removed the self invoking function and passed `window` and `document` in a safe time to use those references
