### PR TITLE
Fixes issue that prevented truncated markup from changing when underlying text changed

### DIFF
--- a/addon/components/truncate-multiline.js
+++ b/addon/components/truncate-multiline.js
@@ -116,12 +116,41 @@ export default Ember.Component.extend(ResizeHandlerMixin, {
   _didTruncate: false,
 
   /**
+   * Resets the component when the `text` attribute of the component has changed
+   * @return {Void}
+   */
+  didUpdateAttrs(attrs) {
+    this._super(attrs);
+    if (attrs.oldAttrs.text && attrs.newAttrs.text && attrs.oldAttrs.text.value !== attrs.newAttrs.text.value) {
+      this._resetState();
+    }
+  },
+
+  /**
    * Kicks off the truncation after render.
    * @return {Void}
    */
   didRender() {
+    this._super(...arguments);
     if (!this.get('_didTruncate')) {
       this._doTruncation();
+    }
+  },
+
+  /**
+   * Resets the state of the component
+   * @return {Void}
+   * @private
+   */
+  _resetState() {
+    let truncate = this.get('truncate');
+    if (truncate) {
+      // trigger a rerender/retruncate
+      this.set('_didTruncate', false);
+      this.set('truncate', false);
+      Ember.run.scheduleOnce('afterRender', this, () => {
+        this.set('truncate', truncate);
+      });
     }
   },
 
@@ -154,15 +183,7 @@ export default Ember.Component.extend(ResizeHandlerMixin, {
    * @return {Void}
    */
   resize() {
-    let truncate = this.get('truncate');
-    if (truncate) {
-      // trigger a rerender/retruncate
-      this.set('_didTruncate', false);
-      this.set('truncate', false);
-      Ember.run.scheduleOnce('afterRender', this, () => {
-        this.set('truncate', truncate);
-      });
-    }
+    this._resetState();
   },
 
   /**
@@ -170,7 +191,7 @@ export default Ember.Component.extend(ResizeHandlerMixin, {
    * @property resizeOnInsert
    * @type {Boolean}
    */
-  resizeOnInsert: Ember.computed(() => false),
+  resizeOnInsert: false,
 
   actions: {
     /**

--- a/tests/integration/components/truncate-multiline-test.js
+++ b/tests/integration/components/truncate-multiline-test.js
@@ -289,3 +289,30 @@ test('clicking the see more/less button fires user defined actions', function(as
     assert.deepEqual(args, [false, true], 'onToggleTruncate action triggered (twice) with the expected arguments');
   });
 });
+
+test('changing the component\'s text changes the resulting markup', function(assert) {
+  assert.expect(2);
+
+  this.set('textToTruncate', "supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious");
+
+  this.render(hbs`
+    <div style="width: 362px; font: 16px sans-serif;">
+      {{truncate-multiline text=textToTruncate}}
+    </div>
+  `);
+
+  let this$ = this.$().clone();
+  // remove attributes we have no control over
+  this$.find('[id^=ember]').removeAttr('id');
+  this$.find('[data-ember-action]').removeAttr('data-ember-action');
+
+  assert.equal(this$.html().replace(/\n|  +/g, ''), '<div style="width: 362px; font: 16px sans-serif;"><div class="ember-view"><div class="truncate-multiline--truncation-target"><span>supercalifragilisticexpialidocious </span><span>supercalifragilisticexpialidocious </span><span class="truncate-multiline--last-line-wrapper"><span class="truncate-multiline--last-line">supercalifragilisticexpialidocious supercalifragilisticexpialidocious</span><button class="truncate-multiline--button">see more</button></span></div></div></div>', 'see more button is hidden');
+
+  this.set('textToTruncate', "supercalifragilisticexpialidocious");
+
+  // remove attributes we have no control over
+  this.$('[id^=ember]').removeAttr('id');
+  this.$('[data-ember-action]').removeAttr('data-ember-action');
+
+  assert.equal(this.$().html().replace(/\n|  +/g, ''), '<div style="width: 362px; font: 16px sans-serif;"><div class="ember-view"><div class="truncate-multiline--truncation-target"><span class="truncate-multiline--last-line-wrapper"><span>supercalifragilisticexpialidocious</span><button class="truncate-multiline--button-hidden"></button></span></div></div></div>');
+});


### PR DESCRIPTION
Now when the text passed to the component changes, the markup will too. Added test for this behavior.