### PR TITLE
Fix a bug in didUpdateAttrs, reset when certain attributes change

### DIFF
--- a/addon/components/truncate-multiline.js
+++ b/addon/components/truncate-multiline.js
@@ -121,7 +121,8 @@ export default Ember.Component.extend(ResizeHandlerMixin, {
    */
   didUpdateAttrs(attrs) {
     this._super(attrs);
-    if (attrs.oldAttrs.text && attrs.newAttrs.text && attrs.oldAttrs.text.value !== attrs.newAttrs.text.value) {
+
+    if (didAttrChange(attrs, 'text') || didAttrChange(attrs, 'truncate') || didAttrChange(attrs, 'lines')) {
       this._resetState();
     }
   },
@@ -213,7 +214,6 @@ export default Ember.Component.extend(ResizeHandlerMixin, {
           }
         }
       } else {
-        this._doTruncation();
         let onCollapse = this.attrs.onCollapse;
 
         if (onCollapse) {
@@ -237,3 +237,38 @@ export default Ember.Component.extend(ResizeHandlerMixin, {
     }
   }
 });
+
+/**
+ * Helper function to determine if an attribute has changed.
+ * @private
+ * @param attrs {Object}
+ * @param name {String}
+ * @return {Boolean}
+ */
+function didAttrChange(attrs, name) {
+  let oldAttr = attrs.oldAttrs[name];
+  let newAttr = attrs.newAttrs[name];
+
+  // If both attrs are undefined, nothing has changed
+  if (oldAttr == null && newAttr == null) {
+    return false;
+  }
+
+  // If only one attr is undefined, it must have changed
+  if (oldAttr == null || newAttr == null) {
+    return true;
+  }
+
+  /**
+  * In integration tests, the attributes passed to 'didUpdateAttrs' are objects,
+  * while in the app they are the values of the attributes themselves.
+  *
+  * However, if the value of the passed attribute hasn't changed it is NOT an object,
+  * it is the value itself.
+  */
+  oldAttr = oldAttr.value || oldAttr;
+  newAttr = newAttr.value || newAttr;
+
+  // toString is called in case a user has passed in a SafeString
+  return ((oldAttr.toString && oldAttr.toString() || oldAttr) !== (newAttr.toString && newAttr.toString() || newAttr));
+}

--- a/tests/integration/components/truncate-multiline-test.js
+++ b/tests/integration/components/truncate-multiline-test.js
@@ -142,10 +142,10 @@ test('clicking the button shows/hides full text', function(assert) {
 });
 
 test('truncation can be controlled externally via the truncate attribute', function(assert) {
-  assert.expect(2);
+  assert.expect(3);
 
-  // don't truncate
-  this.set('myTruncate', false);
+  // do truncate
+  this.set('myTruncate', true);
 
   // Template block usage:
   this.render(hbs`
@@ -158,17 +158,23 @@ test('truncation can be controlled externally via the truncate attribute', funct
   // remove attributes we have no control over
   this$.find('[id^=ember]').removeAttr('id');
   this$.find('[data-ember-action]').removeAttr('data-ember-action');
+  assert.equal(this$.html().replace(/\n|  +/g, ''), '<div style="width: 362px; font: 16px sans-serif;"><div class="ember-view"><div class="truncate-multiline--truncation-target"><span>supercalifragilisticexpialidocious </span><span>supercalifragilisticexpialidocious </span><span class="truncate-multiline--last-line-wrapper"><span class="truncate-multiline--last-line">supercalifragilisticexpialidocious supercalifragilisticexpialidocious</span><button class="truncate-multiline--button">see more</button></span></div></div></div>', 'truncation when myTruncate=true');
 
-  assert.equal(this$.html().replace(/\n|  +/g, ''), '<div style="width: 362px; font: 16px sans-serif;"><div class="ember-view">supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious<button class="truncate-multiline--button-hidden"><!----></button></div></div>', 'no truncation when myTruncate=false');
+  // don't truncate
+  this.set('myTruncate', false);
 
-  // do truncate
+  // remove attributes we have no control over
+  this.$('[id^=ember]').removeAttr('id');
+  this.$('[data-ember-action]').removeAttr('data-ember-action');
+  assert.equal(this.$().html().replace(/\n|  +/g, ''), '<div style="width: 362px; font: 16px sans-serif;"><div class="ember-view">supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious<button class="truncate-multiline--button">see less</button></div></div>', 'no truncation when myTruncate=false');
+
+  // do truncate again to ensure it works
   this.set('myTruncate', true);
 
   // remove attributes we have no control over
   this.$('[id^=ember]').removeAttr('id');
   this.$('[data-ember-action]').removeAttr('data-ember-action');
-
-  assert.equal(this.$().html().replace(/\n|  +/g, ''), '<div style="width: 362px; font: 16px sans-serif;"><div class="ember-view"><div class="truncate-multiline--truncation-target"><span>supercalifragilisticexpialidocious </span><span>supercalifragilisticexpialidocious </span><span class="truncate-multiline--last-line-wrapper"><span class="truncate-multiline--last-line">supercalifragilisticexpialidocious supercalifragilisticexpialidocious</span><button class="truncate-multiline--button">see more</button></span></div></div></div>', 'truncation when myTruncate=true');
+  assert.equal(this.$().html().replace(/\n|  +/g, ''), '<div style="width: 362px; font: 16px sans-serif;"><div class="ember-view"><div class="truncate-multiline--truncation-target"><span>supercalifragilisticexpialidocious </span><span>supercalifragilisticexpialidocious </span><span class="truncate-multiline--last-line-wrapper"><span class="truncate-multiline--last-line">supercalifragilisticexpialidocious supercalifragilisticexpialidocious</span><button class="truncate-multiline--button">see more</button></span></div></div></div>', 'truncations again when myTruncate=true');
 });
 
 test('passing showSeeMoreButton=false hides the "see more" button', function(assert) {
@@ -306,7 +312,7 @@ test('changing the component\'s text changes the resulting markup', function(ass
   this$.find('[id^=ember]').removeAttr('id');
   this$.find('[data-ember-action]').removeAttr('data-ember-action');
 
-  assert.equal(this$.html().replace(/\n|  +/g, ''), '<div style="width: 362px; font: 16px sans-serif;"><div class="ember-view"><div class="truncate-multiline--truncation-target"><span>supercalifragilisticexpialidocious </span><span>supercalifragilisticexpialidocious </span><span class="truncate-multiline--last-line-wrapper"><span class="truncate-multiline--last-line">supercalifragilisticexpialidocious supercalifragilisticexpialidocious</span><button class="truncate-multiline--button">see more</button></span></div></div></div>', 'see more button is hidden');
+  assert.equal(this$.html().replace(/\n|  +/g, ''), '<div style="width: 362px; font: 16px sans-serif;"><div class="ember-view"><div class="truncate-multiline--truncation-target"><span>supercalifragilisticexpialidocious </span><span>supercalifragilisticexpialidocious </span><span class="truncate-multiline--last-line-wrapper"><span class="truncate-multiline--last-line">supercalifragilisticexpialidocious supercalifragilisticexpialidocious</span><button class="truncate-multiline--button">see more</button></span></div></div></div>', 'original text is rendered correctly');
 
   this.set('textToTruncate', "supercalifragilisticexpialidocious");
 
@@ -314,5 +320,35 @@ test('changing the component\'s text changes the resulting markup', function(ass
   this.$('[id^=ember]').removeAttr('id');
   this.$('[data-ember-action]').removeAttr('data-ember-action');
 
-  assert.equal(this.$().html().replace(/\n|  +/g, ''), '<div style="width: 362px; font: 16px sans-serif;"><div class="ember-view"><div class="truncate-multiline--truncation-target"><span class="truncate-multiline--last-line-wrapper"><span>supercalifragilisticexpialidocious</span><button class="truncate-multiline--button-hidden"></button></span></div></div></div>');
+  assert.equal(this.$().html().replace(/\n|  +/g, ''), '<div style="width: 362px; font: 16px sans-serif;"><div class="ember-view"><div class="truncate-multiline--truncation-target"><span class="truncate-multiline--last-line-wrapper"><span>supercalifragilisticexpialidocious</span><button class="truncate-multiline--button-hidden"></button></span></div></div></div>', 'new text is rendered correctly');
+});
+
+test('changing the component\'s lines changes the resulting markup', function(assert) {
+  assert.expect(2);
+
+  this.set('lineToTruncate', 2);
+
+  this.render(hbs`
+    <div style="width: 362px; font: 16px sans-serif;">
+      {{truncate-multiline
+        text="supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious"
+        lines=lineToTruncate
+      }}
+    </div>
+  `);
+
+  let this$ = this.$().clone();
+  // remove attributes we have no control over
+  this$.find('[id^=ember]').removeAttr('id');
+  this$.find('[data-ember-action]').removeAttr('data-ember-action');
+
+  assert.equal(this$.html().replace(/\n|  +/g, ''), '<div style="width: 362px; font: 16px sans-serif;"><div class="ember-view"><div class="truncate-multiline--truncation-target"><span>supercalifragilisticexpialidocious </span><span class="truncate-multiline--last-line-wrapper"><span class="truncate-multiline--last-line">supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious</span><button class="truncate-multiline--button">see more</button></span></div></div></div>', 'original text is rendered correctly');
+
+  this.set('lineToTruncate', 3);
+
+  // remove attributes we have no control over
+  this.$('[id^=ember]').removeAttr('id');
+  this.$('[data-ember-action]').removeAttr('data-ember-action');
+
+  assert.equal(this.$().html().replace(/\n|  +/g, ''), '<div style="width: 362px; font: 16px sans-serif;"><div class="ember-view"><div class="truncate-multiline--truncation-target"><span>supercalifragilisticexpialidocious </span><span>supercalifragilisticexpialidocious </span><span class="truncate-multiline--last-line-wrapper"><span class="truncate-multiline--last-line">supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious</span><button class="truncate-multiline--button">see more</button></span></div></div></div>', 'new number of lines is respected');
 });


### PR DESCRIPTION
This fixes a bug in didUpdateAttrs and now correctly resets the state after either `truncate`, `lines`, or `text` changes.