### PR TITLE
Support for being imported in another addon

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,13 @@
 
 module.exports = {
   name: 'ember-truncate',
-  included: function(app) {
-    app.import('vendor/styles/truncate-multiline.css');
+  included: function(app, parentAddon) {
+    var target = (parentAddon || app);
+
+    if (target.app) {
+      target = target.app;
+    }
+
+    target.import('vendor/styles/truncate-multiline.css');
   }
 };


### PR DESCRIPTION
@nickiaconis 
Right now, this addon can be only included in an app. When included in another addon, it throws up an error saying app.import is not a function. This Pull Request fixes it and works for both addons and apps.

For more info, see here -
https://github.com/ember-cli/ember-cli/issues/3718