### PR TITLE
Add button A11Y support

### DIFF
--- a/addon/components/truncate-multiline.js
+++ b/addon/components/truncate-multiline.js
@@ -93,6 +93,18 @@ export default Ember.Component.extend(ResizeHandlerMixin, {
   seeLessButtonText: 'see less',
 
   /**
+   * The text to speak aloud in the "see more" button.
+   * @type {String}
+   */
+  seeMoreButtonA11yText: '',
+
+  /**
+   * The text to speak aloud in the "see less" button.
+   * @type {String}
+   */
+  seeLessButtonA11yText: '',
+
+  /**
    * Whether or not the "see more" button should be visible.
    * @property _shouldShowSeeMoreButton
    * @type {Boolean}
@@ -107,6 +119,10 @@ export default Ember.Component.extend(ResizeHandlerMixin, {
    * @private
    */
   _shouldShowSeeLessButton: Ember.computed.and('showButton', 'showSeeLessButton', 'isTruncated'),
+
+  _shouldSupportSeeMoreButtonA11y: Ember.computed('_shouldShowSeeMoreButton', 'seeMoreButtonText', 'seeMoreButtonA11yText', shouldSupportButtonA11y('More')),
+
+  _shouldSupportSeeLessButtonA11y: Ember.computed('_shouldShowSeeLessButton', 'seeLessButtonText', 'seeLessButtonA11yText', shouldSupportButtonA11y('Less')),
 
   /**
    * Keeps track of whether or not _doTruncate has been run.
@@ -240,6 +256,16 @@ export default Ember.Component.extend(ResizeHandlerMixin, {
     }
   }
 });
+
+function shouldSupportButtonA11y(type) {
+  return function compute() {
+    const shouldShowButton = this.get(`_shouldShowSee${type}Button`);
+    const seeButtonText = this.getWithDefault(`see${type}ButtonText`, '').trim();
+    const seeButtonA11yText = this.getWithDefault(`see${type}ButtonA11yText`, '').trim();
+
+    return shouldShowButton && seeButtonA11yText.length && seeButtonText !== seeButtonA11yText;
+  };
+}
 
 /**
  * Helper function to determine if an attribute has changed.

--- a/addon/templates/components/truncate-multiline.hbs
+++ b/addon/templates/components/truncate-multiline.hbs
@@ -7,7 +7,12 @@
     {{~/if~}}
   </div>
   <button class="truncate-multiline--button{{if _shouldShowSeeMoreButton "" "-hidden"}}" {{action "toggleTruncate"}}>
-    {{if _shouldShowSeeMoreButton seeMoreButtonText ""}}
+    {{#if _shouldSupportSeeMoreButtonA11y}}
+      <span aria-hidden="true">{{seeMoreButtonText}}</span>
+      <span class="truncate-multiline--visually-hidden">{{seeMoreButtonA11yText}}</span>
+    {{else if _shouldShowSeeMoreButton}}
+      {{seeMoreButtonText}}
+    {{/if}}
   </button>
 {{else}}
   {{#if hasBlock}}
@@ -16,6 +21,11 @@
     {{text}}
   {{/if}}
   <button class="truncate-multiline--button{{if _shouldShowSeeLessButton "" "-hidden"}}" {{action "toggleTruncate"}}>
-    {{if _shouldShowSeeLessButton seeLessButtonText ""}}
+    {{#if _shouldSupportSeeLessButtonA11y}}
+      <span aria-hidden="true">{{seeLessButtonText}}</span>
+      <span class="truncate-multiline--visually-hidden">{{seeLessButtonA11yText}}</span>
+    {{else if _shouldShowSeeLessButton}}
+      {{seeLessButtonText}}
+    {{/if}}
   </button>
 {{/if}}

--- a/tests/integration/components/truncate-multiline-test.js
+++ b/tests/integration/components/truncate-multiline-test.js
@@ -194,7 +194,6 @@ test('specifying different button texts works', function(assert) {
 });
 
 test('specifying different button a11y texts works', function(assert) {
-  // Template block usage:
   this.render(hbs`
     <div style="width: 362px; font: 16px sans-serif;">
       {{truncate-multiline seeMoreButtonText="click me" seeMoreButtonA11yText="Show more about this test" seeLessButtonText="then click me" seeLessButtonA11yText="Show less about this test" text="supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious"}}
@@ -204,7 +203,7 @@ test('specifying different button a11y texts works', function(assert) {
   assert.equal(
     this.$('.truncate-multiline--visually-hidden').text().trim(),
     'Show more about this test',
-    'custom "see more" and a11y text is correct'
+    'custom "see more" a11y text is correct'
   );
 
   this.$('button').click();
@@ -212,12 +211,11 @@ test('specifying different button a11y texts works', function(assert) {
   assert.equal(
     this.$('.truncate-multiline--visually-hidden').text().trim(),
     'Show less about this test',
-    'custom "see less" and a11y text is correct'
+    'custom "see less" a11y text is correct'
   );
 });
 
 test('specifying equal button and a11y texts works', function(assert) {
-  // Template block usage:
   this.render(hbs`
     <div style="width: 362px; font: 16px sans-serif;">
       {{truncate-multiline seeMoreButtonText="click me" seeMoreButtonA11yText="click me" seeLessButtonText="then click me" seeLessButtonA11yText="then click me" text="supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious"}}
@@ -233,7 +231,7 @@ test('specifying equal button and a11y texts works', function(assert) {
   assert.equal(
     this.$('.truncate-multiline--visually-hidden').length,
     0,
-    'custom a11y text is not present'
+    'custom "see more" a11y text is not present'
   );
 
   this.$('button').click();
@@ -247,7 +245,7 @@ test('specifying equal button and a11y texts works', function(assert) {
   assert.equal(
     this.$('.truncate-multiline--visually-hidden').length,
     0,
-    'custom a11y text is not present'
+    'custom "see less" a11y text is not present'
   );
 });
 

--- a/tests/integration/components/truncate-multiline-test.js
+++ b/tests/integration/components/truncate-multiline-test.js
@@ -98,6 +98,52 @@ test('specifying different button texts works', function(assert) {
   assert.equal(this.$().html().replace(/\n|  +/g, ''), '<div style="width: 362px; font: 16px sans-serif;"><div class="ember-view">supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious<button class="truncate-multiline--button">then click me</button></div></div>', 'custom "see less" text is correct');
 });
 
+test('specifying different button a11y texts works', function(assert) {
+  // Template block usage:
+  this.render(hbs`
+    <div style="width: 362px; font: 16px sans-serif;">
+      {{truncate-multiline seeMoreButtonText="click me" seeMoreButtonA11yText="Show more about this test" seeLessButtonText="then click me" seeLessButtonA11yText="Show less about this test" text="supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious"}}
+    </div>
+  `);
+
+  let this$ = this.$().clone();
+  // remove attributes we have no control over
+  this$.find('[id^=ember]').removeAttr('id');
+  this$.find('[data-ember-action]').removeAttr('data-ember-action');
+
+  assert.equal(this$.html().replace(/\n|  +/g, ''), '<div style="width: 362px; font: 16px sans-serif;"><div class="ember-view"><div class="truncate-multiline--truncation-target"><span>supercalifragilisticexpialidocious </span><span>supercalifragilisticexpialidocious </span><span class="truncate-multiline--last-line-wrapper"><span class="truncate-multiline--last-line">supercalifragilisticexpialidocious supercalifragilisticexpialidocious</span><button class="truncate-multiline--button"><span aria-hidden=\"true\">click me</span><span class=\"truncate-multiline--visually-hidden\">Show more about this test</span></button></span></div></div></div>', 'custom "see more" text and a11y is correct');
+
+  this.$('button').click();
+  // remove attributes we have no control over
+  this.$('[id^=ember]').removeAttr('id');
+  this.$('[data-ember-action]').removeAttr('data-ember-action');
+
+  assert.equal(this.$().html().replace(/\n|  +/g, ''), '<div style="width: 362px; font: 16px sans-serif;"><div class="ember-view">supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious<button class="truncate-multiline--button"><span aria-hidden=\"true\">then click me</span><span class=\"truncate-multiline--visually-hidden\">Show less about this test</span></button></div></div>', 'custom "see less" text and a11y is correct');
+});
+
+test('specifying equal button and a11y texts works', function(assert) {
+  // Template block usage:
+  this.render(hbs`
+    <div style="width: 362px; font: 16px sans-serif;">
+      {{truncate-multiline seeMoreButtonText="click me" seeMoreButtonA11yText="click me" seeLessButtonText="then click me" seeLessButtonA11yText="then click me" text="supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious"}}
+    </div>
+  `);
+
+  let this$ = this.$().clone();
+  // remove attributes we have no control over
+  this$.find('[id^=ember]').removeAttr('id');
+  this$.find('[data-ember-action]').removeAttr('data-ember-action');
+
+  assert.equal(this$.html().replace(/\n|  +/g, ''), '<div style="width: 362px; font: 16px sans-serif;"><div class="ember-view"><div class="truncate-multiline--truncation-target"><span>supercalifragilisticexpialidocious </span><span>supercalifragilisticexpialidocious </span><span class="truncate-multiline--last-line-wrapper"><span class="truncate-multiline--last-line">supercalifragilisticexpialidocious supercalifragilisticexpialidocious</span><button class="truncate-multiline--button">click me</button></span></div></div></div>', 'custom "see more" text is correct');
+
+  this.$('button').click();
+  // remove attributes we have no control over
+  this.$('[id^=ember]').removeAttr('id');
+  this.$('[data-ember-action]').removeAttr('data-ember-action');
+
+  assert.equal(this.$().html().replace(/\n|  +/g, ''), '<div style="width: 362px; font: 16px sans-serif;"><div class="ember-view">supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious<button class="truncate-multiline--button">then click me</button></div></div>', 'custom "see less" text is correct');
+});
+
 test('the button is hidden if the text isn\'t long enough to truncate', function(assert) {
   // Template block usage:
   this.render(hbs`
@@ -268,7 +314,7 @@ test('resizing triggers truncation recompute', function(assert) {
   this.$('[data-ember-action]').removeAttr('data-ember-action');
 
   assert.equal(this.$('#truncate-multiline--test-container')[0].style.width, '540px', 'the container was resized');
-  assert.equal(this.$('#truncate-multiline--test-container').html().replace(/\n|  +/g, ''), '<div class="ember-view"><div class="truncate-multiline--truncation-target"><span>supercalifragilisticexpialidocious supercalifragilisticexpialidocious </span><span class="truncate-multiline--last-line-wrapper"><span>supercalifragilisticexpialidocious supercalifragilisticexpialidocious</span><button class="truncate-multiline--button-hidden"></button></span></div></div>', 'truncation after resizing');
+  assert.equal(this.$('#truncate-multiline--test-container').html().replace(/\n|  +/g, ''), '<div class="ember-view"><div class="truncate-multiline--truncation-target"><span>supercalifragilisticexpialidocious supercalifragilisticexpialidocious </span><span class="truncate-multiline--last-line-wrapper"><span>supercalifragilisticexpialidocious supercalifragilisticexpialidocious</span><button class="truncate-multiline--button-hidden"><!----></button></span></div></div>', 'truncation after resizing');
 });
 
 test('clicking the see more/less button fires user defined actions', function(assert) {
@@ -326,7 +372,7 @@ test('changing the component\'s text changes the resulting markup', function(ass
   this.$('[id^=ember]').removeAttr('id');
   this.$('[data-ember-action]').removeAttr('data-ember-action');
 
-  assert.equal(this.$().html().replace(/\n|  +/g, ''), '<div style="width: 362px; font: 16px sans-serif;"><div class="ember-view"><div class="truncate-multiline--truncation-target"><span class="truncate-multiline--last-line-wrapper"><span>supercalifragilisticexpialidocious</span><button class="truncate-multiline--button-hidden"></button></span></div></div></div>', 'new text is rendered correctly');
+  assert.equal(this.$().html().replace(/\n|  +/g, ''), '<div style="width: 362px; font: 16px sans-serif;"><div class="ember-view"><div class="truncate-multiline--truncation-target"><span class="truncate-multiline--last-line-wrapper"><span>supercalifragilisticexpialidocious</span><button class="truncate-multiline--button-hidden"><!----></button></span></div></div></div>', 'new text is rendered correctly');
 });
 
 test('changing the component\'s lines changes the resulting markup', function(assert) {

--- a/tests/integration/components/truncate-multiline-test.js
+++ b/tests/integration/components/truncate-multiline-test.js
@@ -201,19 +201,19 @@ test('specifying different button a11y texts works', function(assert) {
     </div>
   `);
 
-  let this$ = this.$().clone();
-  // remove attributes we have no control over
-  this$.find('[id^=ember]').removeAttr('id');
-  this$.find('[data-ember-action]').removeAttr('data-ember-action');
-
-  assert.equal(this$.html().replace(/\n|  +/g, ''), '<div style="width: 362px; font: 16px sans-serif;"><div class="ember-view"><div class="truncate-multiline--truncation-target"><span>supercalifragilisticexpialidocious </span><span>supercalifragilisticexpialidocious </span><span class="truncate-multiline--last-line-wrapper"><span class="truncate-multiline--last-line">supercalifragilisticexpialidocious supercalifragilisticexpialidocious</span><button class="truncate-multiline--button"><span aria-hidden=\"true\">click me</span><span class=\"truncate-multiline--visually-hidden\">Show more about this test</span></button></span></div></div></div>', 'custom "see more" text and a11y is correct');
+  assert.equal(
+    this.$('.truncate-multiline--visually-hidden').text().trim(),
+    'Show more about this test',
+    'custom "see more" and a11y text is correct'
+  );
 
   this.$('button').click();
-  // remove attributes we have no control over
-  this.$('[id^=ember]').removeAttr('id');
-  this.$('[data-ember-action]').removeAttr('data-ember-action');
 
-  assert.equal(this.$().html().replace(/\n|  +/g, ''), '<div style="width: 362px; font: 16px sans-serif;"><div class="ember-view">supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious<button class="truncate-multiline--button"><span aria-hidden=\"true\">then click me</span><span class=\"truncate-multiline--visually-hidden\">Show less about this test</span></button></div></div>', 'custom "see less" text and a11y is correct');
+  assert.equal(
+    this.$('.truncate-multiline--visually-hidden').text().trim(),
+    'Show less about this test',
+    'custom "see less" and a11y text is correct'
+  );
 });
 
 test('specifying equal button and a11y texts works', function(assert) {
@@ -224,19 +224,31 @@ test('specifying equal button and a11y texts works', function(assert) {
     </div>
   `);
 
-  let this$ = this.$().clone();
-  // remove attributes we have no control over
-  this$.find('[id^=ember]').removeAttr('id');
-  this$.find('[data-ember-action]').removeAttr('data-ember-action');
+  assert.equal(
+    this.$('.truncate-multiline--button').text().trim(),
+    'click me',
+    'custom "see more" text is correct'
+  );
 
-  assert.equal(this$.html().replace(/\n|  +/g, ''), '<div style="width: 362px; font: 16px sans-serif;"><div class="ember-view"><div class="truncate-multiline--truncation-target"><span>supercalifragilisticexpialidocious </span><span>supercalifragilisticexpialidocious </span><span class="truncate-multiline--last-line-wrapper"><span class="truncate-multiline--last-line">supercalifragilisticexpialidocious supercalifragilisticexpialidocious</span><button class="truncate-multiline--button">click me</button></span></div></div></div>', 'custom "see more" text is correct');
+  assert.equal(
+    this.$('.truncate-multiline--visually-hidden').length,
+    0,
+    'custom a11y text is not present'
+  );
 
   this.$('button').click();
-  // remove attributes we have no control over
-  this.$('[id^=ember]').removeAttr('id');
-  this.$('[data-ember-action]').removeAttr('data-ember-action');
 
-  assert.equal(this.$().html().replace(/\n|  +/g, ''), '<div style="width: 362px; font: 16px sans-serif;"><div class="ember-view">supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious<button class="truncate-multiline--button">then click me</button></div></div>', 'custom "see less" text is correct');
+  assert.equal(
+    this.$('.truncate-multiline--button').text().trim(),
+    'then click me',
+    'custom "see less" text is correct'
+  );
+
+  assert.equal(
+    this.$('.truncate-multiline--visually-hidden').length,
+    0,
+    'custom a11y text is not present'
+  );
 });
 
 test('the button is hidden if the text isn\'t long enough to truncate', function(assert) {

--- a/vendor/styles/truncate-multiline.css
+++ b/vendor/styles/truncate-multiline.css
@@ -19,3 +19,14 @@
 .truncate-multiline--last-line-wrapper {
   display: flex !important;
 }
+
+.truncate-multiline--visually-hidden {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}


### PR DESCRIPTION
Currently, the toggle button does not permit the addition of dedicated A11Y text. This commit optionally adds it.