### PR TITLE
convert BR tags to space

### DIFF
--- a/addon/utils/clamp.js
+++ b/addon/utils/clamp.js
@@ -70,8 +70,18 @@ export default (function(win, doc) {
 
     // get all nodes and remove them
     while (el.firstChild !== null) {
-      seedQueue.push(el.firstChild);
-      el.removeChild(el.firstChild);
+      // conver BR tag to space
+      if (el.firstChild.tagName === 'BR') {
+        seedQueue.push(ctn(' '));
+        el.removeChild(el.firstChild);
+        // remove remaining BR tags in a sequence
+        while (el.firstChild !== null && el.firstChild.tagName === 'BR') {
+          el.removeChild(el.firstChild);
+        }
+      } else {
+        seedQueue.push(el.firstChild);
+        el.removeChild(el.firstChild);
+      }
     }
 
     // add measurement element within so it inherits styles


### PR DESCRIPTION
This PR is for the following issue:
Ember Truncate is unable to convert <br> to space 

When to be truncated element is like following:

I want to change the world for the better; but then again, don't we all? 

My approach to changing the world is through advancing public health. I am passionate about a wide range of public health issues, particularly those involving disease surveillance and improving health systems to yield better results. See less

it's unable to convert 
to space and return truncated content as:

I want to change the world for the better; but then again, don't we all?My approach to changing the world is through advancing public health. I am passionate about a wide range of public health issues, particularly those involving disease surveillance and improving health systems to yield better results. See more
Please notice " don't we all?My approach to" their is no space between "?" and "My"