### PR TITLE
Fix the Test Suite

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,22 +13,8 @@ insert_final_newline = true
 indent_style = space
 indent_size = 2
 
-[*.js]
-indent_style = space
-indent_size = 2
-
 [*.hbs]
 insert_final_newline = false
-indent_style = space
-indent_size = 2
-
-[*.css]
-indent_style = space
-indent_size = 2
-
-[*.html]
-indent_style = space
-indent_size = 2
 
 [*.{diff,md}]
 trim_trailing_whitespace = false

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# See http://help.github.com/ignore-files/ for more about ignoring files.
+# See https://help.github.com/ignore-files/ for more about ignoring files.
 
 # compiled output
 /dist
@@ -13,5 +13,5 @@
 /connect.lock
 /coverage/*
 /libpeerconnection.log
-npm-debug.log
+npm-debug.log*
 testem.log

--- a/.jshintrc
+++ b/.jshintrc
@@ -27,6 +27,6 @@
   "strict": false,
   "white": false,
   "eqnull": true,
-  "esnext": true,
+  "esversion": 6,
   "unused": true
 }

--- a/.npmignore
+++ b/.npmignore
@@ -8,6 +8,7 @@
 .editorconfig
 .ember-cli
 .gitignore
+.jshintrc
 .watchmanconfig
 .travis.yml
 bower.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,22 @@
+---
 language: node_js
-
 node_js:
-  - "5"
+  - "4"
 
 sudo: false
 
 cache:
   directories:
-    - node_modules
-    - bower_components
+    - $HOME/.npm
+    - $HOME/.cache # includes bowers cache
 
 env:
-  global:
-    - CXX=g++-4.8
-  matrix:
-    - EMBER_TRY_SCENARIO=default
-    - EMBER_TRY_SCENARIO=ember-1.13
-    - EMBER_TRY_SCENARIO=ember-release
-    - EMBER_TRY_SCENARIO=ember-beta
-    - EMBER_TRY_SCENARIO=ember-canary
-
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-    packages:
-      - g++-4.8
+  # we recommend testing LTS's and latest stable release (bonus points to beta/canary)
+  - EMBER_TRY_SCENARIO=ember-lts-2.4
+  - EMBER_TRY_SCENARIO=ember-lts-2.8
+  - EMBER_TRY_SCENARIO=ember-release
+  - EMBER_TRY_SCENARIO=ember-beta
+  - EMBER_TRY_SCENARIO=ember-canary
 
 matrix:
   fast_finish: true
@@ -33,14 +24,16 @@ matrix:
     - env: EMBER_TRY_SCENARIO=ember-canary
 
 before_install:
-  - export PATH=/usr/local/phantomjs-2.0.0/bin:$PATH
-  - "npm config set spin false"
-  - "phantomjs --version"
+  - npm config set spin false
+  - npm install -g bower phantomjs-prebuilt
+  - bower --version
+  - phantomjs --version
 
 install:
-  - npm install -g bower
   - npm install
   - bower install
 
 script:
-  - ember try:one $EMBER_TRY_SCENARIO
+  # Usually, it's ok to finish the test scenario without reverting
+  #  to the addon's original dependency state, skipping "cleanup".
+  - node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO test --skip-cleanup

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015
+Copyright (c) 2017
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/addon/components/truncate-multiline.js
+++ b/addon/components/truncate-multiline.js
@@ -49,6 +49,13 @@ export default Ember.Component.extend(ResizeHandlerMixin, {
   truncate: true,
 
   /**
+   * Internal state of whether or not to truncate the text.
+   * @type {Boolean}
+   * @private
+   */
+  _truncate: true,
+
+  /**
    * Whether the text needed truncating or was short enough already.
    * @property isTruncated
    * @type {Boolean}
@@ -122,6 +129,10 @@ export default Ember.Component.extend(ResizeHandlerMixin, {
   didUpdateAttrs(attrs) {
     this._super(attrs);
 
+    if (didAttrChange(attrs, 'truncate')) {
+      this.set('_truncate', this.get('truncate'));
+    }
+
     if (didAttrChange(attrs, 'text') || didAttrChange(attrs, 'truncate') || didAttrChange(attrs, 'lines')) {
       this._resetState();
     }
@@ -144,13 +155,13 @@ export default Ember.Component.extend(ResizeHandlerMixin, {
    * @private
    */
   _resetState() {
-    let truncate = this.get('truncate');
+    let truncate = this.get('_truncate');
     if (truncate) {
       // trigger a rerender/retruncate
       this.set('_didTruncate', false);
-      this.set('truncate', false);
+      this.set('_truncate', false);
       Ember.run.scheduleOnce('afterRender', this, () => {
-        this.set('truncate', truncate);
+        this.set('_truncate', truncate);
       });
     }
   },
@@ -161,7 +172,7 @@ export default Ember.Component.extend(ResizeHandlerMixin, {
    * @private
    */
   _doTruncation() {
-    if (this.get('truncate')) {
+    if (this.get('_truncate')) {
       Ember.run.scheduleOnce('afterRender', this, () => {
         let el = this.element.querySelector(`.${cssNamespace}--truncation-target`);
         let button = this.element.querySelector(`[class^=${cssNamespace}--button]`);
@@ -200,8 +211,8 @@ export default Ember.Component.extend(ResizeHandlerMixin, {
      * @return {Void}
      */
     toggleTruncate() {
-      let wasTruncated = this.get('truncate');
-      this.toggleProperty('truncate');
+      let wasTruncated = this.get('_truncate');
+      this.toggleProperty('_truncate');
 
       if (wasTruncated) {
         let onExpand = this.attrs.onExpand;
@@ -273,5 +284,8 @@ function didAttrChange(attrs, name) {
   newAttr = newAttr.value || newAttr;
 
   // toString is called in case a user has passed in a SafeString
-  return ((oldAttr.toString && oldAttr.toString() || oldAttr) !== (newAttr.toString && newAttr.toString() || newAttr));
+  oldAttr = oldAttr.toString && oldAttr.toString() || oldAttr;
+  newAttr = newAttr.toString && newAttr.toString() || newAttr;
+
+  return oldAttr !== newAttr;
 }

--- a/addon/templates/components/truncate-multiline.hbs
+++ b/addon/templates/components/truncate-multiline.hbs
@@ -1,4 +1,4 @@
-{{#if truncate}}
+{{#if _truncate}}
   <div class="truncate-multiline--truncation-target">
     {{~#if hasBlock~}}
       {{yield}}

--- a/bower.json
+++ b/bower.json
@@ -1,9 +1,4 @@
 {
   "name": "ember-truncate",
-  "dependencies": {
-    "ember": "~2.5.0",
-    "ember-cli-shims": "0.1.1",
-    "ember-cli-test-loader": "0.2.2",
-    "ember-qunit-notifications": "0.1.0"
-  }
+  "dependencies": {}
 }

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -2,19 +2,34 @@
 module.exports = {
   scenarios: [
     {
-      name: 'default',
+      name: 'ember-lts-2.4',
       bower: {
-        dependencies: { }
+        dependencies: {
+          'ember': 'components/ember#lts-2-4'
+        },
+        resolutions: {
+          'ember': 'lts-2-4'
+        }
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null
+        }
       }
     },
     {
-      name: 'ember-1.13',
+      name: 'ember-lts-2.8',
       bower: {
         dependencies: {
-          'ember': '~1.13.0'
+          'ember': 'components/ember#lts-2-8'
         },
         resolutions: {
-          'ember': '~1.13.0'
+          'ember': 'lts-2-8'
+        }
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null
         }
       }
     },
@@ -27,6 +42,11 @@ module.exports = {
         resolutions: {
           'ember': 'release'
         }
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null
+        }
       }
     },
     {
@@ -38,6 +58,11 @@ module.exports = {
         resolutions: {
           'ember': 'beta'
         }
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null
+        }
       }
     },
     {
@@ -48,6 +73,11 @@ module.exports = {
         },
         resolutions: {
           'ember': 'canary'
+        }
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null
         }
       }
     }

--- a/config/environment.js
+++ b/config/environment.js
@@ -1,3 +1,4 @@
+/*jshint node:true*/
 'use strict';
 
 module.exports = function(/* environment, appConfig */) {

--- a/package.json
+++ b/package.json
@@ -2,40 +2,6 @@
   "name": "ember-truncate",
   "version": "0.1.3",
   "description": "A generic component used to truncate text to a specified number of lines.",
-  "directories": {
-    "doc": "doc",
-    "test": "tests"
-  },
-  "scripts": {
-    "build": "ember build",
-    "start": "ember server",
-    "test": "ember try:testall"
-  },
-  "repository": "https://github.com/nickiaconis/ember-truncate",
-  "engines": {
-    "node": ">= 0.10.0"
-  },
-  "author": "",
-  "license": "MIT",
-  "devDependencies": {
-    "broccoli-asset-rev": "^2.4.2",
-    "ember-cli": "2.5.1",
-    "ember-cli-app-version": "^1.0.0",
-    "ember-cli-dependency-checker": "^1.2.0",
-    "ember-cli-htmlbars-inline-precompile": "^0.3.1",
-    "ember-cli-inject-live-reload": "^1.4.0",
-    "ember-cli-jshint": "^1.0.3",
-    "ember-cli-qunit": "^1.4.2",
-    "ember-cli-release": "0.2.8",
-    "ember-cli-sri": "^2.1.0",
-    "ember-cli-uglify": "^1.2.0",
-    "ember-disable-prototype-extensions": "^1.1.0",
-    "ember-export-application-global": "^1.0.5",
-    "ember-load-initializers": "^0.5.1",
-    "ember-resolver": "^2.0.3",
-    "ember-try": "^0.2.2",
-    "loader.js": "^4.0.1"
-  },
   "keywords": [
     "ember-addon",
     "components",
@@ -44,10 +10,45 @@
     "overflow",
     "ellipsis"
   ],
+  "license": "MIT",
+  "author": "Nick Iaconis",
+  "directories": {
+    "doc": "doc",
+    "test": "tests"
+  },
+  "repository": "https://github.com/nickiaconis/ember-truncate",
+  "scripts": {
+    "build": "ember build",
+    "start": "ember server",
+    "test": "ember try:each"
+  },
   "dependencies": {
-    "ember-cli-babel": "^5.1.6",
-    "ember-cli-htmlbars": "^1.0.3",
-    "ember-singularity-mixins": "^1.2.0"
+    "ember-cli-babel": "^5.1.7",
+    "ember-cli-htmlbars": "^1.1.1",
+    "ember-singularity-mixins": "^1.3.1"
+  },
+  "devDependencies": {
+    "broccoli-asset-rev": "^2.4.5",
+    "ember-cli": "2.11.0",
+    "ember-cli-app-version": "^2.0.0",
+    "ember-cli-dependency-checker": "^1.3.0",
+    "ember-cli-htmlbars-inline-precompile": "^0.3.3",
+    "ember-cli-inject-live-reload": "^1.4.1",
+    "ember-cli-jshint": "^2.0.1",
+    "ember-cli-qunit": "^3.0.1",
+    "ember-cli-shims": "^1.0.2",
+    "ember-cli-sri": "^2.1.0",
+    "ember-cli-test-loader": "^1.1.1",
+    "ember-cli-uglify": "^1.2.0",
+    "ember-disable-prototype-extensions": "^1.1.0",
+    "ember-export-application-global": "^1.0.5",
+    "ember-load-initializers": "^0.6.0",
+    "ember-resolver": "^2.0.3",
+    "ember-source": "~2.11.0",
+    "loader.js": "^4.0.10"
+  },
+  "engines": {
+    "node": ">= 0.12.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/tests/.jshintrc
+++ b/tests/.jshintrc
@@ -47,6 +47,6 @@
   "strict": false,
   "white": false,
   "eqnull": true,
-  "esnext": true,
+  "esversion": 6,
   "unused": true
 }

--- a/tests/dummy/app/index.html
+++ b/tests/dummy/app/index.html
@@ -9,16 +9,16 @@
 
     {{content-for "head"}}
 
-    <link rel="stylesheet" href="assets/vendor.css">
-    <link rel="stylesheet" href="assets/dummy.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/dummy.css">
 
     {{content-for "head-footer"}}
   </head>
   <body>
     {{content-for "body"}}
 
-    <script src="assets/vendor.js"></script>
-    <script src="assets/dummy.js"></script>
+    <script src="{{rootURL}}assets/vendor.js"></script>
+    <script src="{{rootURL}}assets/dummy.js"></script>
 
     {{content-for "body-footer"}}
   </body>

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -2,7 +2,8 @@ import Ember from 'ember';
 import config from './config/environment';
 
 const Router = Ember.Router.extend({
-  location: config.locationType
+  location: config.locationType,
+  rootURL: config.rootURL
 });
 
 Router.map(function() {

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -4,12 +4,16 @@ module.exports = function(environment) {
   var ENV = {
     modulePrefix: 'dummy',
     environment: environment,
-    baseURL: '/',
+    rootURL: '/',
     locationType: 'auto',
     EmberENV: {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build
         // e.g. 'with-controller': true
+      },
+      EXTEND_PROTOTYPES: {
+        // Prevent Ember Data from overriding Date.parse.
+        Date: false
       }
     },
 
@@ -29,7 +33,6 @@ module.exports = function(environment) {
 
   if (environment === 'test') {
     // Testem prefers this...
-    ENV.baseURL = '/';
     ENV.locationType = 'none';
 
     // keep test console output quieter

--- a/tests/helpers/module-for-acceptance.js
+++ b/tests/helpers/module-for-acceptance.js
@@ -1,6 +1,9 @@
 import { module } from 'qunit';
+import Ember from 'ember';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
+
+const { RSVP: { Promise } } = Ember;
 
 export default function(name, options = {}) {
   module(name, {
@@ -8,16 +11,13 @@ export default function(name, options = {}) {
       this.application = startApp();
 
       if (options.beforeEach) {
-        options.beforeEach.apply(this, arguments);
+        return options.beforeEach.apply(this, arguments);
       }
     },
 
     afterEach() {
-      if (options.afterEach) {
-        options.afterEach.apply(this, arguments);
-      }
-
-      destroyApp(this.application);
+      let afterEach = options.afterEach && options.afterEach.apply(this, arguments);
+      return Promise.resolve(afterEach).then(() => destroyApp(this.application));
     }
   });
 }

--- a/tests/index.html
+++ b/tests/index.html
@@ -10,9 +10,9 @@
     {{content-for "head"}}
     {{content-for "test-head"}}
 
-    <link rel="stylesheet" href="assets/vendor.css">
-    <link rel="stylesheet" href="assets/dummy.css">
-    <link rel="stylesheet" href="assets/test-support.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/dummy.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/test-support.css">
 
     {{content-for "head-footer"}}
     {{content-for "test-head-footer"}}
@@ -21,12 +21,11 @@
     {{content-for "body"}}
     {{content-for "test-body"}}
 
-    <script src="testem.js" integrity=""></script>
-    <script src="assets/vendor.js"></script>
-    <script src="assets/test-support.js"></script>
-    <script src="assets/dummy.js"></script>
-    <script src="assets/tests.js"></script>
-    <script src="assets/test-loader.js"></script>
+    <script src="/testem.js" integrity=""></script>
+    <script src="{{rootURL}}assets/vendor.js"></script>
+    <script src="{{rootURL}}assets/test-support.js"></script>
+    <script src="{{rootURL}}assets/dummy.js"></script>
+    <script src="{{rootURL}}assets/tests.js"></script>
 
     {{content-for "body-footer"}}
     {{content-for "test-body-footer"}}

--- a/tests/integration/components/truncate-multiline-test.js
+++ b/tests/integration/components/truncate-multiline-test.js
@@ -19,11 +19,48 @@ moduleForComponent('truncate-multiline', 'Integration | Component | truncate-mul
 test('inline form works', function(assert) {
   this.render(hbs`<div style="width: 362px; font: 16px sans-serif;">{{truncate-multiline text="supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious"}}</div>`);
 
-  // remove attributes we have no control over
-  this.$('[id^=ember]').removeAttr('id');
-  this.$('[data-ember-action]').removeAttr('data-ember-action');
-
-  assert.equal(this.$().html().replace(/\n|  +/g, ''), '<div style="width: 362px; font: 16px sans-serif;"><div class="ember-view"><div class="truncate-multiline--truncation-target"><span>supercalifragilisticexpialidocious </span><span>supercalifragilisticexpialidocious </span><span class="truncate-multiline--last-line-wrapper"><span class="truncate-multiline--last-line">supercalifragilisticexpialidocious supercalifragilisticexpialidocious</span><button class="truncate-multiline--button">see more</button></span></div></div></div>');
+  const $truncationTarget = this.$('.truncate-multiline--truncation-target');
+  const $truncationChunks = $truncationTarget.children();
+  const $lastChunkWrapper = $truncationChunks.slice(-1);
+  const $lastChunkEtc = $lastChunkWrapper.children();
+  assert.ok(
+    $truncationTarget,
+    'the truncation target exists'
+  );
+  assert.equal(
+    $truncationChunks.length,
+    3,
+    'text is truncated into chunks (default 3)'
+  );
+  assert.ok(
+    $truncationChunks.slice(0, 2)
+      .toArray()
+      .every((chunk) => chunk.innerText.trim() === 'supercalifragilisticexpialidocious'),
+    'first chunks contain expected text'
+  );
+  assert.ok(
+    $lastChunkWrapper.hasClass('truncate-multiline--last-line-wrapper'),
+    'last-line-wrapper class is applied to last chunk wrapper'
+  );
+  assert.equal(
+    $lastChunkEtc.length,
+    2,
+    'last chunk wrapper contains two elements'
+  );
+  assert.ok(
+    $lastChunkEtc[0].classList.contains('truncate-multiline--last-line'),
+    'first element in last chunk wrapper is the last chunk'
+  );
+  assert.equal(
+    $lastChunkEtc[0].innerText,
+    'supercalifragilisticexpialidocious supercalifragilisticexpialidocious',
+    'last chunk contains expected text'
+  );
+  assert.ok(
+    $lastChunkEtc[1].tagName.toLowerCase() === 'button' &&
+    $lastChunkEtc[1].classList.contains('truncate-multiline--button'),
+    'second element in last chunk wrapper is the expand button'
+  );
 });
 
 test('block form works', function(assert) {
@@ -36,11 +73,48 @@ test('block form works', function(assert) {
     </div>
   `);
 
-  // remove attributes we have no control over
-  this.$('[id^=ember]').removeAttr('id');
-  this.$('[data-ember-action]').removeAttr('data-ember-action');
-
-  assert.equal(this.$().html().replace(/\n|  +/g, ''), '<div style="width: 362px; font: 16px sans-serif;"><div class="ember-view"><div class="truncate-multiline--truncation-target"><span>supercalifragilisticexpialidocious </span><span>supercalifragilisticexpialidocious </span><span class="truncate-multiline--last-line-wrapper"><span class="truncate-multiline--last-line">supercalifragilisticexpialidocious supercalifragilisticexpialidocious</span><button class="truncate-multiline--button">see more</button></span></div></div></div>');
+  const $truncationTarget = this.$('.truncate-multiline--truncation-target');
+  const $truncationChunks = $truncationTarget.children();
+  const $lastChunkWrapper = $truncationChunks.slice(-1);
+  const $lastChunkEtc = $lastChunkWrapper.children();
+  assert.ok(
+    $truncationTarget,
+    'the truncation target exists'
+  );
+  assert.equal(
+    $truncationChunks.length,
+    3,
+    'text is truncated into chunks (default 3)'
+  );
+  assert.ok(
+    $truncationChunks.slice(0, 2)
+      .toArray()
+      .every((chunk) => chunk.innerText.trim() === 'supercalifragilisticexpialidocious'),
+    'first chunks contain expected text'
+  );
+  assert.ok(
+    $lastChunkWrapper.hasClass('truncate-multiline--last-line-wrapper'),
+    'last-line-wrapper class is applied to last chunk wrapper'
+  );
+  assert.equal(
+    $lastChunkEtc.length,
+    2,
+    'last chunk wrapper contains two elements'
+  );
+  assert.ok(
+    $lastChunkEtc[0].classList.contains('truncate-multiline--last-line'),
+    'first element in last chunk wrapper is the last chunk'
+  );
+  assert.equal(
+    $lastChunkEtc[0].innerText,
+    'supercalifragilisticexpialidocious supercalifragilisticexpialidocious',
+    'last chunk contains expected text'
+  );
+  assert.ok(
+    $lastChunkEtc[1].tagName.toLowerCase() === 'button' &&
+    $lastChunkEtc[1].classList.contains('truncate-multiline--button'),
+    'second element in last chunk wrapper is the expand button'
+  );
 });
 
 test('block form with nested elements works', function(assert) {
@@ -53,11 +127,18 @@ test('block form with nested elements works', function(assert) {
     </div>
   `);
 
-  // remove attributes we have no control over
-  this.$('[id^=ember]').removeAttr('id');
-  this.$('[data-ember-action]').removeAttr('data-ember-action');
-
-  assert.equal(this.$().html().replace(/\n|  +/g, ''), '<div style="width: 362px; font: 16px sans-serif;"><div class="ember-view"><div class="truncate-multiline--truncation-target"><span><b><i>supercalifragilisticexpialidocious </i></b></span><span><b><i>supercalifragilisticexpialidocious</i></b> <i>a <b>e</b> i</i> </span><span class="truncate-multiline--last-line-wrapper"><span class="truncate-multiline--last-line">supercalifragilisticexpialidocious supercalifragilisticexpialidocious</span><button class="truncate-multiline--button">see more</button></span></div></div></div>');
+  const $truncationTarget = this.$('.truncate-multiline--truncation-target');
+  const $truncationChunks = $truncationTarget.children();
+  assert.equal(
+    $truncationChunks[0].innerHTML,
+    '<b><i>supercalifragilisticexpialidocious </i></b>',
+    'first chunk contains expected html'
+  );
+  assert.equal(
+    $truncationChunks[1].innerHTML,
+    '<b><i>supercalifragilisticexpialidocious</i></b> <i>a <b>e</b> i</i> ',
+    'second chunk contains expected html'
+  );
 });
 
 test('specifying a different number of lines works', function(assert) {
@@ -68,11 +149,25 @@ test('specifying a different number of lines works', function(assert) {
     </div>
   `);
 
-  // remove attributes we have no control over
-  this.$('[id^=ember]').removeAttr('id');
-  this.$('[data-ember-action]').removeAttr('data-ember-action');
-
-  assert.equal(this.$().html().replace(/\n|  +/g, ''), '<div style="width: 362px; font: 16px sans-serif;"><div class="ember-view"><div class="truncate-multiline--truncation-target"><span>supercalifragilisticexpialidocious </span><span class="truncate-multiline--last-line-wrapper"><span class="truncate-multiline--last-line">supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious</span><button class="truncate-multiline--button">see more</button></span></div></div></div>');
+  const $truncationTarget = this.$('.truncate-multiline--truncation-target');
+  const $truncationChunks = $truncationTarget.children();
+  const $lastChunkWrapper = $truncationChunks.slice(-1);
+  const $lastChunkEtc = $lastChunkWrapper.children();
+  assert.equal(
+    $truncationChunks.length,
+    2,
+    'text is truncated into specified number of chunks'
+  );
+  assert.equal(
+    $truncationChunks[0].innerText,
+    'supercalifragilisticexpialidocious',
+    'first chunk contains expected text'
+  );
+  assert.equal(
+    $lastChunkEtc[0].innerText,
+    'supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious',
+    'last chunk contains expected text'
+  );
 });
 
 test('specifying different button texts works', function(assert) {
@@ -83,19 +178,19 @@ test('specifying different button texts works', function(assert) {
     </div>
   `);
 
-  let this$ = this.$().clone();
-  // remove attributes we have no control over
-  this$.find('[id^=ember]').removeAttr('id');
-  this$.find('[data-ember-action]').removeAttr('data-ember-action');
-
-  assert.equal(this$.html().replace(/\n|  +/g, ''), '<div style="width: 362px; font: 16px sans-serif;"><div class="ember-view"><div class="truncate-multiline--truncation-target"><span>supercalifragilisticexpialidocious </span><span>supercalifragilisticexpialidocious </span><span class="truncate-multiline--last-line-wrapper"><span class="truncate-multiline--last-line">supercalifragilisticexpialidocious supercalifragilisticexpialidocious</span><button class="truncate-multiline--button">click me</button></span></div></div></div>', 'custom "see more" text is correct');
+  assert.equal(
+    this.$('.truncate-multiline--button').text().trim(),
+    'click me',
+    'custom "see more" text is correct'
+  );
 
   this.$('button').click();
-  // remove attributes we have no control over
-  this.$('[id^=ember]').removeAttr('id');
-  this.$('[data-ember-action]').removeAttr('data-ember-action');
 
-  assert.equal(this.$().html().replace(/\n|  +/g, ''), '<div style="width: 362px; font: 16px sans-serif;"><div class="ember-view">supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious<button class="truncate-multiline--button">then click me</button></div></div>', 'custom "see less" text is correct');
+  assert.equal(
+    this.$('.truncate-multiline--button').text().trim(),
+    'then click me',
+    'custom "see less" text is correct'
+  );
 });
 
 test('the button is hidden if the text isn\'t long enough to truncate', function(assert) {
@@ -106,16 +201,25 @@ test('the button is hidden if the text isn\'t long enough to truncate', function
     </div>
   `);
 
-  // remove attributes we have no control over
-  this.$('[id^=ember]').removeAttr('id');
-  this.$('[data-ember-action]').removeAttr('data-ember-action');
-
-  assert.equal(this.$().html().replace(/\n|  +/g, ''), '<div style="width: 362px; font: 16px sans-serif;"><div class="ember-view"><div class="truncate-multiline--truncation-target"><span>supercalifragilisticexpialidocious </span><span class="truncate-multiline--last-line-wrapper"><span>supercalifragilisticexpialidocious</span><button class="truncate-multiline--button-hidden"><!----></button></span></div></div></div>');
+  const $hiddenButton = this.$('.truncate-multiline--button-hidden');
+  assert.equal(
+    this.$('truncate-multiline--button').length,
+    0,
+    'button class is not applied'
+  );
+  assert.equal(
+    $hiddenButton.length,
+    1,
+    'button-hidden class is applied'
+  );
+  assert.equal(
+    $hiddenButton.text().trim(),
+    '',
+    'button contains no text'
+  );
 });
 
-test('clicking the button shows/hides full text', function(assert) {
-  assert.expect(3);
-
+test('clicking the button toggles full text', function(assert) {
   // Template block usage:
   this.render(hbs`
     <div style="width: 362px; font: 16px sans-serif;">
@@ -123,33 +227,31 @@ test('clicking the button shows/hides full text', function(assert) {
     </div>
   `);
 
-  let $clone1 = this.$().clone();
-  // remove attributes we have no control over
-  $clone1.find('[id^=ember]').removeAttr('id');
-  $clone1.find('[data-ember-action]').removeAttr('data-ember-action');
-
-  assert.equal($clone1.html().replace(/\n|  +/g, ''), '<div style="width: 362px; font: 16px sans-serif;"><div class="ember-view"><div class="truncate-multiline--truncation-target"><span>supercalifragilisticexpialidocious </span><span>supercalifragilisticexpialidocious </span><span class="truncate-multiline--last-line-wrapper"><span class="truncate-multiline--last-line">supercalifragilisticexpialidocious supercalifragilisticexpialidocious</span><button class="truncate-multiline--button">see more</button></span></div></div></div>', 'truncated before clicking button');
-
-  this.$('button').click();
-  let $clone2 = this.$().clone();
-  // remove attributes we have no control over
-  $clone2.find('[id^=ember]').removeAttr('id');
-  $clone2.find('[data-ember-action]').removeAttr('data-ember-action');
-
-  assert.equal($clone2.html().replace(/\n|  +/g, ''), '<div style="width: 362px; font: 16px sans-serif;"><div class="ember-view">supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious<button class="truncate-multiline--button">see less</button></div></div>', 'not truncated after clicking button');
+  const $component = this.$('.truncate-multiline--truncation-target').parent();
+  assert.equal(
+    this.$('.truncate-multiline--truncation-target').children().length,
+    3,
+    'truncated before clicking button'
+  );
 
   this.$('button').click();
-  let $clone3 = this.$().clone();
-  // remove attributes we have no control over
-  $clone3.find('[id^=ember]').removeAttr('id');
-  $clone3.find('[data-ember-action]').removeAttr('data-ember-action');
 
-  assert.equal($clone3.html().replace(/\n|  +/g, ''), '<div style="width: 362px; font: 16px sans-serif;"><div class="ember-view"><div class="truncate-multiline--truncation-target"><span>supercalifragilisticexpialidocious </span><span>supercalifragilisticexpialidocious </span><span class="truncate-multiline--last-line-wrapper"><span class="truncate-multiline--last-line">supercalifragilisticexpialidocious supercalifragilisticexpialidocious</span><button class="truncate-multiline--button">see more</button></span></div></div></div>', 'truncated after clicking button again');
+  assert.equal(
+    $component[0].firstChild.wholeText.trim(),
+    'supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious',
+    'not truncated after clicking button'
+  );
+
+  this.$('button').click();
+
+  assert.equal(
+    this.$('.truncate-multiline--truncation-target').children().length,
+    3,
+    'truncated after clicking button again'
+  );
 });
 
 test('truncation can be controlled externally via the truncate attribute', function(assert) {
-  assert.expect(3);
-
   // do truncate
   this.set('myTruncate', true);
 
@@ -160,27 +262,30 @@ test('truncation can be controlled externally via the truncate attribute', funct
     </div>
   `);
 
-  let this$ = this.$().clone();
-  // remove attributes we have no control over
-  this$.find('[id^=ember]').removeAttr('id');
-  this$.find('[data-ember-action]').removeAttr('data-ember-action');
-  assert.equal(this$.html().replace(/\n|  +/g, ''), '<div style="width: 362px; font: 16px sans-serif;"><div class="ember-view"><div class="truncate-multiline--truncation-target"><span>supercalifragilisticexpialidocious </span><span>supercalifragilisticexpialidocious </span><span class="truncate-multiline--last-line-wrapper"><span class="truncate-multiline--last-line">supercalifragilisticexpialidocious supercalifragilisticexpialidocious</span><button class="truncate-multiline--button">see more</button></span></div></div></div>', 'truncation when myTruncate=true');
+  const $component = this.$('.truncate-multiline--truncation-target').parent();
+  assert.equal(
+    this.$('.truncate-multiline--truncation-target').children().length,
+    3,
+    'truncation when myTruncate=true'
+  );
 
   // don't truncate
   this.set('myTruncate', false);
 
-  // remove attributes we have no control over
-  this.$('[id^=ember]').removeAttr('id');
-  this.$('[data-ember-action]').removeAttr('data-ember-action');
-  assert.equal(this.$().html().replace(/\n|  +/g, ''), '<div style="width: 362px; font: 16px sans-serif;"><div class="ember-view">supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious<button class="truncate-multiline--button">see less</button></div></div>', 'no truncation when myTruncate=false');
+  assert.equal(
+    $component[0].firstChild.wholeText.trim(),
+    'supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious',
+    'no truncation when myTruncate=false'
+  );
 
   // do truncate again to ensure it works
   this.set('myTruncate', true);
 
-  // remove attributes we have no control over
-  this.$('[id^=ember]').removeAttr('id');
-  this.$('[data-ember-action]').removeAttr('data-ember-action');
-  assert.equal(this.$().html().replace(/\n|  +/g, ''), '<div style="width: 362px; font: 16px sans-serif;"><div class="ember-view"><div class="truncate-multiline--truncation-target"><span>supercalifragilisticexpialidocious </span><span>supercalifragilisticexpialidocious </span><span class="truncate-multiline--last-line-wrapper"><span class="truncate-multiline--last-line">supercalifragilisticexpialidocious supercalifragilisticexpialidocious</span><button class="truncate-multiline--button">see more</button></span></div></div></div>', 'truncations again when myTruncate=true');
+  assert.equal(
+    this.$('.truncate-multiline--truncation-target').children().length,
+    3,
+    'truncation again when myTruncate=true'
+  );
 });
 
 test('passing showSeeMoreButton=false hides the "see more" button', function(assert) {
@@ -191,11 +296,22 @@ test('passing showSeeMoreButton=false hides the "see more" button', function(ass
     </div>
   `);
 
-  // remove attributes we have no control over
-  this.$('[id^=ember]').removeAttr('id');
-  this.$('[data-ember-action]').removeAttr('data-ember-action');
-
-  assert.equal(this.$().html().replace(/\n|  +/g, ''), '<div style="width: 362px; font: 16px sans-serif;"><div class="ember-view"><div class="truncate-multiline--truncation-target"><span>supercalifragilisticexpialidocious </span><span>supercalifragilisticexpialidocious </span><span class="truncate-multiline--last-line-wrapper"><span class="truncate-multiline--last-line">supercalifragilisticexpialidocious supercalifragilisticexpialidocious</span><button class="truncate-multiline--button-hidden"><!----></button></span></div></div></div>', 'see more button is hidden');
+  const $hiddenButton = this.$('.truncate-multiline--button-hidden');
+  assert.equal(
+    this.$('truncate-multiline--button').length,
+    0,
+    'button class is not applied'
+  );
+  assert.equal(
+    $hiddenButton.length,
+    1,
+    'button-hidden class is applied'
+  );
+  assert.equal(
+    $hiddenButton.text().trim(),
+    '',
+    'button contains no text'
+  );
 });
 
 test('passing showSeeLessButton=false hides the "see less" button', function(assert) {
@@ -208,11 +324,22 @@ test('passing showSeeLessButton=false hides the "see less" button', function(ass
 
   this.$('button').click();
 
-  // remove attributes we have no control over
-  this.$('[id^=ember]').removeAttr('id');
-  this.$('[data-ember-action]').removeAttr('data-ember-action');
-
-  assert.equal(this.$().html().replace(/\n|  +/g, ''), '<div style="width: 362px; font: 16px sans-serif;"><div class="ember-view">supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious<button class="truncate-multiline--button-hidden"><!----></button></div></div>', 'see less butotn is hidden');
+  const $hiddenButton = this.$('.truncate-multiline--button-hidden');
+  assert.equal(
+    this.$('truncate-multiline--button').length,
+    0,
+    'button class is not applied'
+  );
+  assert.equal(
+    $hiddenButton.length,
+    1,
+    'button-hidden class is applied'
+  );
+  assert.equal(
+    $hiddenButton.text().trim(),
+    '',
+    'button contains no text'
+  );
 });
 
 test('passing showButton=false hides both buttons', function(assert) {
@@ -225,25 +352,44 @@ test('passing showButton=false hides both buttons', function(assert) {
     </div>
   `);
 
-  let this$ = this.$().clone();
-  // remove attributes we have no control over
-  this$.find('[id^=ember]').removeAttr('id');
-  this$.find('[data-ember-action]').removeAttr('data-ember-action');
-
-  assert.equal(this$.html().replace(/\n|  +/g, ''), '<div style="width: 362px; font: 16px sans-serif;"><div class="ember-view"><div class="truncate-multiline--truncation-target"><span>supercalifragilisticexpialidocious </span><span>supercalifragilisticexpialidocious </span><span class="truncate-multiline--last-line-wrapper"><span class="truncate-multiline--last-line">supercalifragilisticexpialidocious supercalifragilisticexpialidocious</span><button class="truncate-multiline--button-hidden"><!----></button></span></div></div></div>', 'see more button is hidden');
+  let $hiddenButton = this.$('.truncate-multiline--button-hidden');
+  assert.equal(
+    this.$('truncate-multiline--button').length,
+    0,
+    'button class is not applied'
+  );
+  assert.equal(
+    $hiddenButton.length,
+    1,
+    'button-hidden class is applied'
+  );
+  assert.equal(
+    $hiddenButton.text().trim(),
+    '',
+    'button contains no text'
+  );
 
   this.set('myTruncate', false);
 
-  // remove attributes we have no control over
-  this.$('[id^=ember]').removeAttr('id');
-  this.$('[data-ember-action]').removeAttr('data-ember-action');
-
-  assert.equal(this.$().html().replace(/\n|  +/g, ''), '<div style="width: 362px; font: 16px sans-serif;"><div class="ember-view">supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious<button class="truncate-multiline--button-hidden"><!----></button></div></div>', 'see less button is hidden');
+  $hiddenButton = this.$('.truncate-multiline--button-hidden');
+  assert.equal(
+    this.$('truncate-multiline--button').length,
+    0,
+    'button class is not applied'
+  );
+  assert.equal(
+    $hiddenButton.length,
+    1,
+    'button-hidden class is applied'
+  );
+  assert.equal(
+    $hiddenButton.text().trim(),
+    '',
+    'button contains no text'
+  );
 });
 
 test('resizing triggers truncation recompute', function(assert) {
-  assert.expect(3);
-
   // Template block usage:
   this.render(hbs`
     <div id="truncate-multiline--test-container" style="width: 362px; font: 16px sans-serif;">
@@ -252,23 +398,38 @@ test('resizing triggers truncation recompute', function(assert) {
   `);
 
   // verify initial truncation
-  let this$ = this.$().clone();
-  // remove attributes we have no control over
-  this$.find('[id^=ember]').removeAttr('id');
-  this$.find('[data-ember-action]').removeAttr('data-ember-action');
-
-  assert.equal(this$.html().replace(/\n|  +/g, ''), '<div id="truncate-multiline--test-container" style="width: 362px; font: 16px sans-serif;"><div class="ember-view"><div class="truncate-multiline--truncation-target"><span>supercalifragilisticexpialidocious </span><span>supercalifragilisticexpialidocious </span><span class="truncate-multiline--last-line-wrapper"><span class="truncate-multiline--last-line">supercalifragilisticexpialidocious supercalifragilisticexpialidocious</span><button class="truncate-multiline--button">see more</button></span></div></div></div>', 'truncation before resizing');
+  let $truncationTarget = this.$('.truncate-multiline--truncation-target');
+  let $truncationChunks = $truncationTarget.children();
+  assert.ok(
+    $truncationTarget,
+    'the truncation target exists'
+  );
+  assert.equal(
+    $truncationChunks.length,
+    3,
+    'text is truncated into chunks (default 3)'
+  );
 
   // change container sizing
   this.$('#truncate-multiline--test-container')[0].style.width = '540px';
+
   // trigger resize event
   window.dispatchEvent(new CustomEvent('resize'));
-  // remove attributes we have no control over
-  this.$('[id^=ember]').removeAttr('id');
-  this.$('[data-ember-action]').removeAttr('data-ember-action');
 
+  // verify container size changed
   assert.equal(this.$('#truncate-multiline--test-container')[0].style.width, '540px', 'the container was resized');
-  assert.equal(this.$('#truncate-multiline--test-container').html().replace(/\n|  +/g, ''), '<div class="ember-view"><div class="truncate-multiline--truncation-target"><span>supercalifragilisticexpialidocious supercalifragilisticexpialidocious </span><span class="truncate-multiline--last-line-wrapper"><span>supercalifragilisticexpialidocious supercalifragilisticexpialidocious</span><button class="truncate-multiline--button-hidden"></button></span></div></div>', 'truncation after resizing');
+
+  $truncationTarget = this.$('.truncate-multiline--truncation-target');
+  $truncationChunks = $truncationTarget.children();
+  assert.ok(
+    $truncationTarget,
+    'the truncation target exists'
+  );
+  assert.equal(
+    $truncationChunks.length,
+    2,
+    'text is truncated into fewer chunks (due to expanded width)'
+  );
 });
 
 test('clicking the see more/less button fires user defined actions', function(assert) {
@@ -313,20 +474,22 @@ test('changing the component\'s text changes the resulting markup', function(ass
     </div>
   `);
 
-  let this$ = this.$().clone();
-  // remove attributes we have no control over
-  this$.find('[id^=ember]').removeAttr('id');
-  this$.find('[data-ember-action]').removeAttr('data-ember-action');
-
-  assert.equal(this$.html().replace(/\n|  +/g, ''), '<div style="width: 362px; font: 16px sans-serif;"><div class="ember-view"><div class="truncate-multiline--truncation-target"><span>supercalifragilisticexpialidocious </span><span>supercalifragilisticexpialidocious </span><span class="truncate-multiline--last-line-wrapper"><span class="truncate-multiline--last-line">supercalifragilisticexpialidocious supercalifragilisticexpialidocious</span><button class="truncate-multiline--button">see more</button></span></div></div></div>', 'original text is rendered correctly');
+  let $truncationTarget = this.$('.truncate-multiline--truncation-target').clone();
+  $truncationTarget.find('.truncate-multiline--button').remove();
+  assert.equal(
+    $truncationTarget.text().trim(),
+    'supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious',
+    'original text is rendered'
+  );
 
   this.set('textToTruncate', "supercalifragilisticexpialidocious");
 
-  // remove attributes we have no control over
-  this.$('[id^=ember]').removeAttr('id');
-  this.$('[data-ember-action]').removeAttr('data-ember-action');
-
-  assert.equal(this.$().html().replace(/\n|  +/g, ''), '<div style="width: 362px; font: 16px sans-serif;"><div class="ember-view"><div class="truncate-multiline--truncation-target"><span class="truncate-multiline--last-line-wrapper"><span>supercalifragilisticexpialidocious</span><button class="truncate-multiline--button-hidden"></button></span></div></div></div>', 'new text is rendered correctly');
+  $truncationTarget = this.$('.truncate-multiline--truncation-target').clone();
+  assert.equal(
+    $truncationTarget.text().trim(),
+    'supercalifragilisticexpialidocious',
+    'new text is rendered'
+  );
 });
 
 test('changing the component\'s lines changes the resulting markup', function(assert) {
@@ -343,18 +506,19 @@ test('changing the component\'s lines changes the resulting markup', function(as
     </div>
   `);
 
-  let this$ = this.$().clone();
-  // remove attributes we have no control over
-  this$.find('[id^=ember]').removeAttr('id');
-  this$.find('[data-ember-action]').removeAttr('data-ember-action');
-
-  assert.equal(this$.html().replace(/\n|  +/g, ''), '<div style="width: 362px; font: 16px sans-serif;"><div class="ember-view"><div class="truncate-multiline--truncation-target"><span>supercalifragilisticexpialidocious </span><span class="truncate-multiline--last-line-wrapper"><span class="truncate-multiline--last-line">supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious</span><button class="truncate-multiline--button">see more</button></span></div></div></div>', 'original text is rendered correctly');
+  let $truncationTarget = this.$('.truncate-multiline--truncation-target');
+  assert.equal(
+    $truncationTarget.children().length,
+    2,
+    'text is rendered into original number of chunks'
+  );
 
   this.set('lineToTruncate', 3);
 
-  // remove attributes we have no control over
-  this.$('[id^=ember]').removeAttr('id');
-  this.$('[data-ember-action]').removeAttr('data-ember-action');
-
-  assert.equal(this.$().html().replace(/\n|  +/g, ''), '<div style="width: 362px; font: 16px sans-serif;"><div class="ember-view"><div class="truncate-multiline--truncation-target"><span>supercalifragilisticexpialidocious </span><span>supercalifragilisticexpialidocious </span><span class="truncate-multiline--last-line-wrapper"><span class="truncate-multiline--last-line">supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious supercalifragilisticexpialidocious</span><button class="truncate-multiline--button">see more</button></span></div></div></div>', 'new number of lines is respected');
+  $truncationTarget = this.$('.truncate-multiline--truncation-target');
+  assert.equal(
+    $truncationTarget.children().length,
+    3,
+    'new number of chunks is respected'
+  );
 });

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -1,7 +1,8 @@
 import resolver from './helpers/resolver';
-import { setResolver } from 'ember-qunit';
+import {
+  setResolver
+} from 'ember-qunit';
 import registerPolyfills from './helpers/polyfills/register';
 
 registerPolyfills();
-
 setResolver(resolver);


### PR DESCRIPTION
Upgrade dependencies and fix the test suite.

No longer makes assertions comparing HTML as strings.

Need to find a work-around for emberjs/ember.js#13948 in order to continue testing external truncation control.