### PR TITLE
Remove trim from shouldSupportButtonA11y

### DIFF
--- a/addon/components/truncate-multiline.js
+++ b/addon/components/truncate-multiline.js
@@ -271,8 +271,8 @@ export default Ember.Component.extend(ResizeHandlerMixin, {
 function shouldSupportButtonA11y(type) {
   return function compute() {
     const shouldShowButton = this.get(`_shouldShowSee${type}Button`);
-    const seeButtonText = this.getWithDefault(`see${type}ButtonText`, '').trim();
-    const seeButtonA11yText = this.getWithDefault(`see${type}ButtonA11yText`, '').trim();
+    const seeButtonText = this.getWithDefault(`see${type}ButtonText`, '');
+    const seeButtonA11yText = this.getWithDefault(`see${type}ButtonA11yText`, '');
 
     return shouldShowButton && seeButtonA11yText.length && seeButtonText !== seeButtonA11yText;
   };


### PR DESCRIPTION
If the a11y text is a safestring, this blows up. We can talk about how to handle safestring at a later time, but need to unblock the code from 0.2.0