### PR TITLE
Address Deprecation of Arguments in Component Lifecycle Hooks

### DIFF
--- a/addon/components/truncate-multiline.js
+++ b/addon/components/truncate-multiline.js
@@ -2,6 +2,7 @@ import Ember from 'ember';
 import ResizeHandlerMixin from 'ember-singularity-mixins/mixins/resize-handler';
 import clamp from 'ember-truncate/utils/clamp';
 import layout from 'ember-truncate/templates/components/truncate-multiline';
+import diffAttrs from 'ember-diff-attrs';
 
 const cssNamespace = 'truncate-multiline';
 
@@ -142,17 +143,17 @@ export default Ember.Component.extend(ResizeHandlerMixin, {
    * Resets the component when the `text` attribute of the component has changed
    * @return {Void}
    */
-  didUpdateAttrs(attrs) {
-    this._super(attrs);
+  didUpdateAttrs: diffAttrs('text', 'truncate', 'lines',  function(changedAttrs, ...args) {
+    this._super(...args);
 
-    if (didAttrChange(attrs, 'truncate')) {
+    if (didAttrChange(changedAttrs.truncate)) {
       this.set('_truncate', this.get('truncate'));
     }
 
-    if (didAttrChange(attrs, 'text') || didAttrChange(attrs, 'truncate') || didAttrChange(attrs, 'lines')) {
+    if (didAttrChange(changedAttrs.text) || didAttrChange(changedAttrs.truncate) || didAttrChange(changedAttrs.lines)) {
       this._resetState();
     }
-  },
+  }),
 
   /**
    * Kicks off the truncation after render.
@@ -281,37 +282,17 @@ function shouldSupportButtonA11y(type) {
 /**
  * Helper function to determine if an attribute has changed.
  * @private
- * @param attrs {Object}
- * @param name {String}
+ * @param attrs {Array}
  * @return {Boolean}
  */
-function didAttrChange(attrs, name) {
-  let oldAttr = attrs.oldAttrs[name];
-  let newAttr = attrs.newAttrs[name];
+function didAttrChange(attrs) {
+  let oldAttr = attrs[0];
+  let newAttr = attrs[1];
 
-  // If both attrs are undefined, nothing has changed
-  if (oldAttr == null && newAttr == null) {
-    return false;
-  }
-
-  // If only one attr is undefined, it must have changed
-  if (oldAttr == null || newAttr == null) {
+  // First run screnarios
+  if (attrs == null || oldAttr == null) {
     return true;
   }
-
-  /**
-  * In integration tests, the attributes passed to 'didUpdateAttrs' are objects,
-  * while in the app they are the values of the attributes themselves.
-  *
-  * However, if the value of the passed attribute hasn't changed it is NOT an object,
-  * it is the value itself.
-  */
-  oldAttr = oldAttr.value || oldAttr;
-  newAttr = newAttr.value || newAttr;
-
-  // toString is called in case a user has passed in a SafeString
-  oldAttr = oldAttr.toString && oldAttr.toString() || oldAttr;
-  newAttr = newAttr.toString && newAttr.toString() || newAttr;
 
   return oldAttr !== newAttr;
 }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "ember-cli-sri": "^2.1.0",
     "ember-cli-test-loader": "^1.1.1",
     "ember-cli-uglify": "^1.2.0",
+    "ember-diff-attrs": "0.1.2",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.6.0",


### PR DESCRIPTION
Will close #20.

This has one failing test with `ember try:one ember-release`. The failing test is showing that the `truncate` option is broken when the value is changed outside of the component, causing it to not re-render. 

I'm pushing this up to hopefully save someone some work down the line or get some points on how to address the failing test. 