### PR TITLE
Support ember fastboot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ cache:
 
 env:
   # we recommend testing LTS's and latest stable release (bonus points to beta/canary)
-  - EMBER_TRY_SCENARIO=ember-lts-2.4
   - EMBER_TRY_SCENARIO=ember-lts-2.8
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta

--- a/addon/components/truncate-multiline.js
+++ b/addon/components/truncate-multiline.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import ResizeHandlerMixin from 'ember-singularity-mixins/mixins/resize-handler';
-import Clamp from 'ember-truncate/utils/clamp';
+import clamp from 'ember-truncate/utils/clamp';
 import layout from 'ember-truncate/templates/components/truncate-multiline';
 import diffAttrs from 'ember-diff-attrs';
 
@@ -202,8 +202,7 @@ export default Ember.Component.extend(ResizeHandlerMixin, {
     let el = this.element.querySelector(`.${cssNamespace}--truncation-target`);
     let button = this.element.querySelector(`[class^=${cssNamespace}--button]`);
     button.parentNode.removeChild(button);
-
-    new Clamp(doc).clamp(el, this.get('lines'), (didTruncate) => this.set('_isTruncated', didTruncate), `${cssNamespace}--last-line`);
+    clamp(el, this.get('lines'), (didTruncate) => this.set('_isTruncated', didTruncate), `${cssNamespace}--last-line`, doc);
     let ellipsizedSpan = el.lastChild;
     el.removeChild(ellipsizedSpan);
     let wrappingSpan = doc.createElement('span');

--- a/addon/components/truncate-multiline.js
+++ b/addon/components/truncate-multiline.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import ResizeHandlerMixin from 'ember-singularity-mixins/mixins/resize-handler';
-import clamp from 'ember-truncate/utils/clamp';
+import Clamp from 'ember-truncate/utils/clamp';
 import layout from 'ember-truncate/templates/components/truncate-multiline';
 import diffAttrs from 'ember-diff-attrs';
 
@@ -28,6 +28,12 @@ const cssNamespace = 'truncate-multiline';
 
 export default Ember.Component.extend(ResizeHandlerMixin, {
   layout: layout,
+
+  /**
+   * Document service uses the browser document object or falls back to
+   * a simple-dom implementation.
+   */
+  document: Ember.inject.service('-document'),
 
   /**
    * The text to truncate. This is overridden if the block form is used.
@@ -191,13 +197,16 @@ export default Ember.Component.extend(ResizeHandlerMixin, {
    * @private
    */
   _doTruncation() {
+    const doc = this.get('document');
+
     let el = this.element.querySelector(`.${cssNamespace}--truncation-target`);
     let button = this.element.querySelector(`[class^=${cssNamespace}--button]`);
     button.parentNode.removeChild(button);
-    clamp(el, this.get('lines'), (didTruncate) => this.set('_isTruncated', didTruncate), `${cssNamespace}--last-line`);
+
+    new Clamp(doc).clamp(el, this.get('lines'), (didTruncate) => this.set('_isTruncated', didTruncate), `${cssNamespace}--last-line`);
     let ellipsizedSpan = el.lastChild;
     el.removeChild(ellipsizedSpan);
-    let wrappingSpan = document.createElement('span');
+    let wrappingSpan = doc.createElement('span');
     wrappingSpan.classList.add(`${cssNamespace}--last-line-wrapper`);
     wrappingSpan.appendChild(ellipsizedSpan);
     wrappingSpan.appendChild(button);

--- a/addon/utils/clamp.js
+++ b/addon/utils/clamp.js
@@ -10,246 +10,237 @@
  * @param {String} cssClass - A CSS class applied to the last line instead of inline CSS.
  */
 
-export default class Clamp {
+function appendNodeAndQueueToElement(element, node, queue, nodeStack) {
+  var queueLength = queue && queue.length,
+      i, aNode, bNode;
+  // add nodes waiting to be finalized
+  for(i = 0; i < queueLength; ++i) {
+    element.appendChild(queue[i]);
+  }
+  if (nodeStack.length) {
+    // add nodes from the stack
+    i = nodeStack.length - 1;
+    // add the text to the last node on the stack
+    nodeStack[i].appendChild(node);
+    // ensure nodes from the stack are appended to each other
+    for (; i > 0 && (aNode = nodeStack[i]).parentNode !== (bNode = nodeStack[i - 1]); --i) {
+      bNode.appendChild(aNode);
+    }
+    // ensure root node from stack is added to measurement node
+    if ((aNode = nodeStack[0]).parentNode !== element) {
+      element.appendChild(aNode);
+    }
+  } else {
+    // add the text directly to the measurement node
+    element.appendChild(node);
+  }
+} // function appendNodeAndQueueToElement
 
-  // Pass in the document object on creation
-  constructor(doc) {
-    this.doc = doc;
+function createMeasureElement(el) {
+  // measurement element is made a child of the clamped element to get it's style
+  var measure = el;
+  measure.style.position = 'absolute'; // prevent page reflow
+  measure.style.whiteSpace = 'pre'; // cross-browser width results
+  measure.style.visibility = 'hidden'; // prevent drawing
+  return measure;
+} // function createMeasureElement
+
+export default function clamp(el, lineClamp, cb, cssClass, doc) {
+  // make sure the element belongs to the document
+  if (!el.ownerDocument || el.ownerDocument !== doc) {
+    return;
   }
 
-  appendNodeAndQueueToElement(element, node, queue, nodeStack) {
-    var queueLength = queue && queue.length,
-        i, aNode, bNode;
-    // add nodes waiting to be finalized
-    for(i = 0; i < queueLength; ++i) {
-      element.appendChild(queue[i]);
-    }
-    if (nodeStack.length) {
-      // add nodes from the stack
-      i = nodeStack.length - 1;
-      // add the text to the last node on the stack
-      nodeStack[i].appendChild(node);
-      // ensure nodes from the stack are appended to each other
-      for (; i > 0 && (aNode = nodeStack[i]).parentNode !== (bNode = nodeStack[i - 1]); --i) {
-        bNode.appendChild(aNode);
-      }
-      // ensure root node from stack is added to measurement node
-      if ((aNode = nodeStack[0]).parentNode !== element) {
-        element.appendChild(aNode);
+  // reset to safe starting values
+  var nodeStack = [];
+  var lineCount = 1;
+  var wasNewLine = false;
+  var lineWidth = el.clientWidth;
+  var seedQueue = [];
+  var pendingQueue = [];
+  var ce = doc.createElement.bind(doc);
+  var ctn = doc.createTextNode.bind(doc);
+  var textNode = null;
+  var thisNode = null;
+  var line = null;
+  var measure = null;
+
+  // get all nodes and remove them
+  while (el.firstChild !== null) {
+    // convert BR tag to space
+    if (el.firstChild.tagName === 'BR') {
+      seedQueue.push(ctn(' '));
+      el.removeChild(el.firstChild);
+      // remove remaining BR tags in a sequence
+      while (el.firstChild !== null && el.firstChild.tagName === 'BR') {
+        el.removeChild(el.firstChild);
       }
     } else {
-      // add the text directly to the measurement node
-      element.appendChild(node);
+      seedQueue.push(el.firstChild);
+      el.removeChild(el.firstChild);
     }
-  } // function appendNodeAndQueueToElement
+  }
 
-  createMeasureElement(el) {
-    // measurement element is made a child of the clamped element to get it's style
-    var measure = el;
-    measure.style.position = 'absolute'; // prevent page reflow
-    measure.style.whiteSpace = 'pre'; // cross-browser width results
-    measure.style.visibility = 'hidden'; // prevent drawing
-    return measure;
-  } // function createMeasureElement
+  // add measurement element within so it inherits styles
+  measure = createMeasureElement(ce('span'));
+  el.appendChild(measure);
 
-  clamp(el, lineClamp, cb, cssClass) {
-    // make sure the element belongs to the document
-    if (!el.ownerDocument || el.ownerDocument !== this.doc) {
-      return;
-    }
+  function clampNodeRecurse(nodeQueue) {
+    var wordStart, pos, text, lineStart,
+        lineText, nextQueue, measureWidth;
 
-    // reset to safe starting values
-    var nodeStack = [];
-    var lineCount = 1;
-    var wasNewLine = false;
-    var lineWidth = el.clientWidth;
-    var seedQueue = [];
-    var pendingQueue = [];
-    var ce = this.doc.createElement.bind(this.doc);
-    var ctn = this.doc.createTextNode.bind(this.doc);
-    var textNode = null;
-    var thisNode = null;
-    var line = null;
-    var measure = null;
-    var anaqte = this.appendNodeAndQueueToElement;
-
-    // get all nodes and remove them
-    while (el.firstChild !== null) {
-      // convert BR tag to space
-      if (el.firstChild.tagName === 'BR') {
-        seedQueue.push(ctn(' '));
-        el.removeChild(el.firstChild);
-        // remove remaining BR tags in a sequence
-        while (el.firstChild !== null && el.firstChild.tagName === 'BR') {
-          el.removeChild(el.firstChild);
-        }
+    function nextWord() {
+      // remember last word start position
+      wordStart = pos + 1;
+      // move to the next word
+      if (pos >= text.length) {
+        pos = text.length + 1;
       } else {
-        seedQueue.push(el.firstChild);
-        el.removeChild(el.firstChild);
-      }
-    }
-
-    // add measurement element within so it inherits styles
-    measure = this.createMeasureElement(ce('span'));
-    el.appendChild(measure);
-
-    function clampNodeRecurse(nodeQueue) {
-      var wordStart, pos, text, lineStart,
-          lineText, nextQueue, measureWidth;
-
-      function nextWord() {
-        // remember last word start position
-        wordStart = pos + 1;
-        // move to the next word
-        if (pos >= text.length) {
-          pos = text.length + 1;
-        } else {
-          pos = text.indexOf(' ', pos + 1);
-          if (pos < 0) {
-            pos = text.length;
-          }
-        }
-      } // function nextWord
-
-      function calculateFit() {
-        // ignore any further processing if we have total lines
-        if (lineCount > lineClamp) {
-          // move to the next word
-          nextWord();
-          return;
-        }
-        // create a text node to measure
-        textNode = ctn(text.substr(lineStart, pos - lineStart));
-        // place relevant nodes into the measurement element
-        anaqte(measure, textNode, pendingQueue, nodeStack);
-        // take the measurement
-        measureWidth = measure.clientWidth;
-        // remove text node from node stack
-        if (nodeStack.length) {
-          nodeStack[nodeStack.length - 1].removeChild(textNode);
-        }
-        // have we exceeded allowed line width?
-        if (lineWidth <= measureWidth) {
-          if(wasNewLine) {
-            // we have a long word so it gets a line of it's own
-            lineText = text.substr(lineStart, Math.min(pos + 1, text.length) - lineStart);
-            // next line start position
-            lineStart = Math.min(pos + 1, text.length);
-            // move to the next word
-            nextWord();
-          } else {
-            // grab the text until this word
-            lineText = text.substr(lineStart, wordStart - lineStart);
-            // next line start position
-            lineStart = wordStart;
-          }
-          // create a line element
-          line = ce('span');
-          // add text to the line element
-          anaqte(line, ctn(lineText), pendingQueue, nodeStack);
-          // add the line element to the container
-          el.appendChild(line);
-          // flush the queue
-          pendingQueue = [];
-          // refresh the stack
-          nodeStack = nodeStack.map((node) => node.cloneNode(false));
-          // yes, we created a new line
-          wasNewLine = true;
-          ++lineCount;
-        } else {
-          // did not create a new line
-          wasNewLine = false;
-          // move to the next word
-          nextWord();
-        }
-        // clear measurement element
-        while (measure.firstChild !== null) {
-          measure.removeChild(measure.firstChild);
-        }
-      } // function calculateFit
-
-      while (nodeQueue.length) {
-        thisNode = nodeQueue.shift();
-        if (thisNode.nodeType === 3 && thisNode.nodeValue) {
-          // text node
-          // get all the text, remove any line changes
-          text = thisNode.nodeValue.replace(/\n/g, ' ');
-          // reset to safe starting values
-          lineStart = wordStart = 0;
-          pos = text.indexOf(' ');
-          // step through the words
-          while (pos <= text.length) {
-            calculateFit();
-          }
-          if (lineStart < text.length) {
-            // there is text that hasn't been appended
-            if (nodeStack.length) {
-              // add the text to the last node on the stack
-              anaqte(null, ctn(text.substr(lineStart)), null, nodeStack);
-              // push the root from the node stack into the queue if it's not already
-              if (pendingQueue.indexOf(nodeStack[0]) < 0) {
-                pendingQueue.push(nodeStack[0]);
-              }
-            } else {
-              // add the text directly to the pending queue
-              pendingQueue.push(ctn(text.substr(lineStart)));
-            }
-          }
-        } else {
-          // element node
-          nextQueue = [];
-          while (thisNode.firstChild !== null) {
-            nextQueue.push(thisNode.firstChild);
-            thisNode.removeChild(thisNode.firstChild);
-          }
-          nodeStack.push(thisNode);
-          clampNodeRecurse(nextQueue);
-          nodeStack.pop();
+        pos = text.indexOf(' ', pos + 1);
+        if (pos < 0) {
+          pos = text.length;
         }
       }
-    } // function clampNodeRecurse
+    } // function nextWord
 
-    // Recurse through all nodes
-    clampNodeRecurse(seedQueue);
-
-    // remove the measurement element from the container
-    el.removeChild(measure);
-
-    // give styles required for text-overflow to kick in
-    if (lineCount > lineClamp) {
-      if ('string' === typeof cssClass) {
-        el.lastChild.classList.add(cssClass);
-      } else {
-        (function(s) {
-          s.display = 'block';
-          s.overflow = 'hidden';
-          s.textOverflow = 'ellipsis';
-          s.whiteSpace = 'nowrap';
-          s.width = '100%';
-        }(el.lastChild.style));
-      }
-    }
-
-    // flush nodes waiting to be appended
-    if (pendingQueue.length) {
+    function calculateFit() {
+      // ignore any further processing if we have total lines
       if (lineCount > lineClamp) {
-        // flush them into the last span
-        while (pendingQueue.length) {
-          el.lastChild.appendChild(pendingQueue.shift());
+        // move to the next word
+        nextWord();
+        return;
+      }
+      // create a text node to measure
+      textNode = ctn(text.substr(lineStart, pos - lineStart));
+      // place relevant nodes into the measurement element
+      appendNodeAndQueueToElement(measure, textNode, pendingQueue, nodeStack);
+      // take the measurement
+      measureWidth = measure.clientWidth;
+      // remove text node from node stack
+      if (nodeStack.length) {
+        nodeStack[nodeStack.length - 1].removeChild(textNode);
+      }
+      // have we exceeded allowed line width?
+      if (lineWidth <= measureWidth) {
+        if(wasNewLine) {
+          // we have a long word so it gets a line of it's own
+          lineText = text.substr(lineStart, Math.min(pos + 1, text.length) - lineStart);
+          // next line start position
+          lineStart = Math.min(pos + 1, text.length);
+          // move to the next word
+          nextWord();
+        } else {
+          // grab the text until this word
+          lineText = text.substr(lineStart, wordStart - lineStart);
+          // next line start position
+          lineStart = wordStart;
         }
-      } else {
-        // create the last line element
+        // create a line element
         line = ce('span');
-        // flush them into the new span
-        while (pendingQueue.length) {
-          line.appendChild(pendingQueue.shift());
-        }
+        // add text to the line element
+        appendNodeAndQueueToElement(line, ctn(lineText), pendingQueue, nodeStack);
         // add the line element to the container
         el.appendChild(line);
+        // flush the queue
+        pendingQueue = [];
+        // refresh the stack
+        nodeStack = nodeStack.map((node) => node.cloneNode(false));
+        // yes, we created a new line
+        wasNewLine = true;
+        ++lineCount;
+      } else {
+        // did not create a new line
+        wasNewLine = false;
+        // move to the next word
+        nextWord();
+      }
+      // clear measurement element
+      while (measure.firstChild !== null) {
+        measure.removeChild(measure.firstChild);
+      }
+    } // function calculateFit
+
+    while (nodeQueue.length) {
+      thisNode = nodeQueue.shift();
+      if (thisNode.nodeType === 3 && thisNode.nodeValue) {
+        // text node
+        // get all the text, remove any line changes
+        text = thisNode.nodeValue.replace(/\n/g, ' ');
+        // reset to safe starting values
+        lineStart = wordStart = 0;
+        pos = text.indexOf(' ');
+        // step through the words
+        while (pos <= text.length) {
+          calculateFit();
+        }
+        if (lineStart < text.length) {
+          // there is text that hasn't been appended
+          if (nodeStack.length) {
+            // add the text to the last node on the stack
+            appendNodeAndQueueToElement(null, ctn(text.substr(lineStart)), null, nodeStack);
+            // push the root from the node stack into the queue if it's not already
+            if (pendingQueue.indexOf(nodeStack[0]) < 0) {
+              pendingQueue.push(nodeStack[0]);
+            }
+          } else {
+            // add the text directly to the pending queue
+            pendingQueue.push(ctn(text.substr(lineStart)));
+          }
+        }
+      } else {
+        // element node
+        nextQueue = [];
+        while (thisNode.firstChild !== null) {
+          nextQueue.push(thisNode.firstChild);
+          thisNode.removeChild(thisNode.firstChild);
+        }
+        nodeStack.push(thisNode);
+        clampNodeRecurse(nextQueue);
+        nodeStack.pop();
       }
     }
+  } // function clampNodeRecurse
 
-    // call the callback with whether or not the text was truncated
-    cb(lineCount > lineClamp);
-  } // function clamp
-}
+  // Recurse through all nodes
+  clampNodeRecurse(seedQueue);
+
+  // remove the measurement element from the container
+  el.removeChild(measure);
+
+  // give styles required for text-overflow to kick in
+  if (lineCount > lineClamp) {
+    if ('string' === typeof cssClass) {
+      el.lastChild.classList.add(cssClass);
+    } else {
+      (function(s) {
+        s.display = 'block';
+        s.overflow = 'hidden';
+        s.textOverflow = 'ellipsis';
+        s.whiteSpace = 'nowrap';
+        s.width = '100%';
+      }(el.lastChild.style));
+    }
+  }
+
+  // flush nodes waiting to be appended
+  if (pendingQueue.length) {
+    if (lineCount > lineClamp) {
+      // flush them into the last span
+      while (pendingQueue.length) {
+        el.lastChild.appendChild(pendingQueue.shift());
+      }
+    } else {
+      // create the last line element
+      line = ce('span');
+      // flush them into the new span
+      while (pendingQueue.length) {
+        line.appendChild(pendingQueue.shift());
+      }
+      // add the line element to the container
+      el.appendChild(line);
+    }
+  }
+
+  // call the callback with whether or not the text was truncated
+  cb(lineCount > lineClamp);
+} // function clamp

--- a/bower.json
+++ b/bower.json
@@ -1,9 +1,4 @@
 {
   "name": "ember-truncate",
-  "dependencies": {
-    "ember": "components/ember#canary"
-  },
-  "resolutions": {
-    "ember": "canary"
-  }
+  "dependencies": {}
 }

--- a/bower.json
+++ b/bower.json
@@ -1,4 +1,9 @@
 {
   "name": "ember-truncate",
-  "dependencies": {}
+  "dependencies": {
+    "ember": "components/ember#canary"
+  },
+  "resolutions": {
+    "ember": "canary"
+  }
 }

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -2,22 +2,6 @@
 module.exports = {
   scenarios: [
     {
-      name: 'ember-lts-2.4',
-      bower: {
-        dependencies: {
-          'ember': 'components/ember#lts-2-4'
-        },
-        resolutions: {
-          'ember': 'lts-2-4'
-        }
-      },
-      npm: {
-        devDependencies: {
-          'ember-source': null
-        }
-      }
-    },
-    {
       name: 'ember-lts-2.8',
       bower: {
         dependencies: {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.6.0",
     "ember-resolver": "^2.0.3",
-    "ember-source": "~2.11.0",
     "loader.js": "^4.0.10"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-truncate",
-  "version": "0.3.3",
+  "version": "0.2.3",
   "description": "A generic component used to truncate text to a specified number of lines.",
   "keywords": [
     "ember-addon",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-truncate",
-  "version": "0.2.3",
+  "version": "0.3.3",
   "description": "A generic component used to truncate text to a specified number of lines.",
   "keywords": [
     "ember-addon",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.6.0",
     "ember-resolver": "^2.0.3",
+    "ember-source": "~2.11.0",
     "loader.js": "^4.0.10"
   },
   "engines": {


### PR DESCRIPTION
The biggest difference is that now `window` and `document` globals aren't being used. Instead we rely on `Ember.inject.service('-document')`. 

I tried to keep the amount of changes required to a minimum in _clamp.js_ - Bumped minor version & tests are all passing. 

Edit: this is a second stab at #8 (and would resolve #7)