### PR TITLE
Bumped ember singularity mixins to 1.3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "ember-cli-babel": "^5.1.7",
     "ember-cli-htmlbars": "^1.1.1",
     "ember-diff-attrs": "^0.1.2",
-    "ember-singularity-mixins": "^1.3.2"
+    "ember-singularity-mixins": "^1.3.3"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",


### PR DESCRIPTION
ember-singularity-mixins v1.3.3 brings in ember-singularity v1.0.4 which brings in a fix to a long time bug around how run.throttle was being used.