### PR TITLE
upgrading ember-diff-attrs

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "ember-cli-babel": "^6.7.1",
     "ember-cli-htmlbars": "^2.0.1",
-    "ember-diff-attrs": "^0.1.2",
+    "ember-diff-attrs": "^0.2.1",
     "ember-lifeline": "^1.3.0",
     "ember-singularity-mixins": "^1.3.3",
     "ember-wormhole": "^0.5.2"


### PR DESCRIPTION
Thank you for this component! Very helpful.

I'm not really sure how it happened but [`ember-diff-attrs@0.1.2`](https://github.com/workmanw/ember-diff-attrs/blob/v0.1.2/package.json#L25) relies on `ember-weakmap@2.0.0` which isn't listed in their [tags](https://github.com/thoov/ember-weakmap/tags).

I'm just updating the `ember-diff-attrs` dependencies here to [`v0.2.1` which relies on `ember-weakmap@3.0.0`](https://github.com/workmanw/ember-diff-attrs/blob/v0.2.1/package.json#L26).